### PR TITLE
Add Markdown from current project

### DIFF
--- a/content/download/index.md
+++ b/content/download/index.md
@@ -9,8 +9,11 @@ meta:
 lang: en-US
 ---
 
+import DownloadButtons from '~/components/download/DownloadButtons.vue'
+import WhatsNew from '~/components/download/WhatsNew.vue'
+
 # Download
-Download the latest stable version of **Tachiyomi** that released <ReleaseDate stable /> or the preview version that released <ReleaseDate preview />.
+Download the latest stable version of **Tachiyomi** that released `<ReleaseDate stable />` or the preview version that released `<ReleaseDate preview />`.
 
 <DownloadButtons />
 

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -1,9 +1,17 @@
 ---
-description: ''
+title: Download
+description: Download links for the latest versions of Tachiyomi.
 prev: '/help/'
 next: '/extensions/'
+meta:
+  - name: keywords
+    content: Download, Official, Android app, Manga, APK
+lang: en-US
 ---
 
 # Download
+Download the latest stable version of **Tachiyomi** that released <ReleaseDate stable /> or the preview version that released <ReleaseDate preview />.
 
-Download the latest stable version of **Tachiyomi** that released **3 months ago** or the preview version that released **3 days ago**.
+<DownloadButtons />
+
+<WhatsNew />

--- a/content/extensions/index.md
+++ b/content/extensions/index.md
@@ -1,8 +1,20 @@
 ---
-description: ''
+title: Extensions
+description: Here is a list of all available extensions to download inside the app.
 prev: '/download/'
+lang: en-US
 ---
 
 # Extensions
 
+:::: el-tabs
+::: el-tab-pane label="Available extensions"
 Here is a list of all available extensions to download inside the app.
+<ExtensionList/>
+:::
+::: el-tab-pane label="Spreadsheet"
+Spreadsheet to help you find sources bundled in multi-source extensions, courtesy of [SnakeDoc83](https://github.com/snakedoc83).
+Now maintained by [Riztard](https://github.com/Riztard) and other volunteers.
+<SourceSheet/>
+:::
+::::

--- a/content/extensions/index.md
+++ b/content/extensions/index.md
@@ -2,6 +2,7 @@
 title: Extensions
 description: Here is a list of all available extensions to download inside the app.
 prev: '/download/'
+next: '/forks/'
 lang: en-US
 ---
 
@@ -10,11 +11,11 @@ lang: en-US
 :::: el-tabs
 ::: el-tab-pane label="Available extensions"
 Here is a list of all available extensions to download inside the app.
-<ExtensionList/>
+`<ExtensionList/>`
 :::
 ::: el-tab-pane label="Spreadsheet"
 Spreadsheet to help you find sources bundled in multi-source extensions, courtesy of [SnakeDoc83](https://github.com/snakedoc83).
 Now maintained by [Riztard](https://github.com/Riztard) and other volunteers.
-<SourceSheet/>
+`<SourceSheet/>`
 :::
 ::::

--- a/content/forks/Neko.md
+++ b/content/forks/Neko.md
@@ -1,5 +1,4 @@
 ---
-layout: ForkPage
 title: Neko
 metaTitle: Neko
 description: MangaDex specific fork of Tachiyomi and TachiyomiJ2K. This contains features specific to MangaDex that those versions cannot offer.
@@ -14,15 +13,15 @@ meta:
 sidebar: false
 ---
 
-# <img class="headerLogo" :src="$withBase('/assets/forks_logo-neko.png')"> Neko
+# ![Alternative text](https://tachiyomi.org/icons/logo.svg) Neko
 
-<ForkButtons forkName="Neko" downloadForkLink="https://api.github.com/repos/CarlosEsco/Neko/releases/latest" downloadForkStyle="background-color:#3DDA83;color:#000000;" githubForkLink="https://github.com/CarlosEsco/Neko" androidVersion="7.0"/>
+`<ForkButtons forkName="Neko" downloadForkLink="https://api.github.com/repos/CarlosEsco/Neko/releases/latest" downloadForkStyle="background-color:#3DDA83;color:#000000;" githubForkLink="https://github.com/CarlosEsco/Neko" androidVersion="7.0"/>`
 
 ## About
 This is a [MangaDex](https://mangadex.org/) specific fork of **Tachiyomi** and [TachiyomiJ2K](/forks/TachiyomiJ2K). This contains features specific to **MangaDex** that those versions cannot offer. It also features almost every feature that **J2K** has except for extensions (aka other sources), custom covers, and local manga.
 
 ## Screenshots
-<img class="zoomable" :src="$withBase('/assets/forks_banner-neko.png')"/>
+`<img class="zoomable" :src="$withBase('/assets/forks_banner-neko.png')"/>`
 
 ## Mangadex specific features:
 - Supports native login to **MangaDex** and supports 2FA

--- a/content/forks/Neko.md
+++ b/content/forks/Neko.md
@@ -1,0 +1,40 @@
+---
+layout: ForkPage
+title: Neko
+metaTitle: Neko
+description: MangaDex specific fork of Tachiyomi and TachiyomiJ2K. This contains features specific to MangaDex that those versions cannot offer.
+lang: en-US
+meta:
+  - property: og:image
+    content: /assets/forks_logo-neko.png
+  - name: theme-color
+    content: "#38CA79"
+  - name: msapplication-TileColor
+    content: "#38CA79"
+sidebar: false
+---
+
+# <img class="headerLogo" :src="$withBase('/assets/forks_logo-neko.png')"> Neko
+
+<ForkButtons forkName="Neko" downloadForkLink="https://api.github.com/repos/CarlosEsco/Neko/releases/latest" downloadForkStyle="background-color:#3DDA83;color:#000000;" githubForkLink="https://github.com/CarlosEsco/Neko" androidVersion="7.0"/>
+
+## About
+This is a [MangaDex](https://mangadex.org/) specific fork of **Tachiyomi** and [TachiyomiJ2K](/forks/TachiyomiJ2K). This contains features specific to **MangaDex** that those versions cannot offer. It also features almost every feature that **J2K** has except for extensions (aka other sources), custom covers, and local manga.
+
+## Screenshots
+<img class="zoomable" :src="$withBase('/assets/forks_banner-neko.png')"/>
+
+## Mangadex specific features:
+- Supports native login to **MangaDex** and supports 2FA
+- MDList support
+- Similar Manga recommendations
+- Manually sync of Manga to and from **MangaDex** follows list
+- MDList tracked manga can be auto marked read in app after reading on the website
+- Ability to filter chapters and skip by scanlator group
+
+## Credits
+- [Inorichi](https://github.com/inorichi/) for making the original **Tachiyomi**
+- [Jays2Kings](https://github.com/Jays2Kings/) for the wonderful new UI of **J2K**
+
+## Disclaimer
+The developer of this application does not have any affiliation with the content providers available.

--- a/content/forks/TachiyomiAZ.md
+++ b/content/forks/TachiyomiAZ.md
@@ -1,5 +1,4 @@
 ---
-layout: ForkPage
 title: TachiyomiAZ
 metaTitle: TachiyomiAZ
 description: This hentai focused fork is based off of TachiyomiEH, it has most features and fixes from Tachiyomi, as well as features from TachiyomiJ2K.
@@ -13,6 +12,7 @@ meta:
     content: "#FFCC4D"
 sidebar: false
 ---
+```css
 <style lang="css">
 @font-face {font-family: "Comic Sans MS"; src: url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.eot"); src: url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.eot?#iefix") format("embedded-opentype"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.woff2") format("woff2"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.woff") format("woff"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.ttf") format("truetype"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.svg#Comic Sans MS") format("svg"); }
 
@@ -79,10 +79,12 @@ sidebar: false
   100% {color: hsl(360, 100%, 50%)}
 }
 </style>
+```
 
-# <img class="headerLogo" :src="$withBase('/assets/forks_logo-az.png')"> TachiyomiAZ
+# ![Alternative text](https://tachiyomi.org/icons/logo.svg) TachiyomiAZ
 
-<ForkButtons forkName="TachiyomiAZ" downloadForkLink="https://api.github.com/repos/az4521/TachiyomiAZ/releases/latest" downloadForkStyle="background-color:#FFCC4D;color:#000000;" githubForkLink="https://github.com/az4521/TachiyomiAZ"/>
+`<ForkButtons forkName="TachiyomiAZ" downloadForkLink="https://api.github.com/repos/az4521/TachiyomiAZ/releases/latest" downloadForkStyle="background-color:#FFCC4D;color:#000000;" githubForkLink="https://github.com/az4521/TachiyomiAZ"/>`
+```
 <div class="overflowContainer">
   <div class="textLoop">
     <div class="textWiggle">
@@ -90,6 +92,7 @@ sidebar: false
     </div>
   </div>
 </div>
+```
 
 ## Introduction
 **TachiyomiAZ** is maintained by **[az4521](https://github.com/az4521)** and [Syer10](https://github.com/jobobby04).
@@ -137,4 +140,4 @@ This hentai focused fork is based off of **[TachiyomiEH](/forks/TachiyomiEH)**, 
 - Grid view corner rounding configuration
 - Manga recommendations
 
-<img class="zoomable" :src="$withBase('/assets/forks_gunz-az.png')">
+`<img class="zoomable" :src="$withBase('/assets/forks_gunz-az.png')">`

--- a/content/forks/TachiyomiAZ.md
+++ b/content/forks/TachiyomiAZ.md
@@ -1,0 +1,140 @@
+---
+layout: ForkPage
+title: TachiyomiAZ
+metaTitle: TachiyomiAZ
+description: This hentai focused fork is based off of TachiyomiEH, it has most features and fixes from Tachiyomi, as well as features from TachiyomiJ2K.
+lang: en-US
+meta:
+  - property: og:image
+    content: /assets/forks_logo-az.png
+  - name: theme-color
+    content: "#FFCC4D"
+  - name: msapplication-TileColor
+    content: "#FFCC4D"
+sidebar: false
+---
+<style lang="css">
+@font-face {font-family: "Comic Sans MS"; src: url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.eot"); src: url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.eot?#iefix") format("embedded-opentype"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.woff2") format("woff2"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.woff") format("woff"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.ttf") format("truetype"), url("//db.onlinewebfonts.com/t/7cc6719bd5f0310be3150ba33418e72e.svg#Comic Sans MS") format("svg"); }
+
+.seizureText {
+  animation: rainbowTextAnim .5s linear infinite, upAndDownAnim 2s infinite;
+}
+.textWiggle {
+  padding: 2em;
+  width: fit-content;
+  animation: wiggleAnim 1s ease-out infinite;
+}
+.textWiggle:hover {
+  animation: doABarrelRoll .6s;
+}
+.bigText {
+  font-family: "Comic Sans MS", "Comic Sans", cursive;
+  font-size: 2em;
+  display: inline-block;
+  -webkit-text-stroke: 1px black;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+.textLoop {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  animation: customMarquee 10s linear infinite;
+  padding-left: 100%;
+}
+.overflowContainer {
+	width:100%;
+	overflow:hidden;
+}
+@keyframes customMarquee {
+  0% {transform: translate(0, 0);}
+  100% {transform: translate(-100%, 0);}
+}
+@keyframes doABarrelRoll {
+  from {transform:rotate(0deg)}
+  to {transform:rotate(360deg)}
+}
+@keyframes wiggleAnim {
+  0%   {transform: rotate(0deg)}
+  25%  {transform: rotate(-15deg)}
+  50%  {transform: rotate(0deg)}
+  75%  {transform: rotate(15deg)}
+  100% {transform: rotate(0deg)}
+}
+@keyframes upAndDownAnim {
+  0% {transform: scaleX(.5) scaleY(.5)}
+  50% {transform: scaleX(1) scaleY(1)}
+  100% {transform: scaleX(.5) scaleY(.5)}
+}
+@keyframes rainbowTextAnim {
+  0%   {color: hsl(0, 100%, 50%)}
+  10%  {color: hsl(36, 100%, 50%)}
+  20%  {color: hsl(72, 100%, 50%)}
+  30%  {color: hsl(108, 100%, 50%)}
+  40%  {color: hsl(144, 100%, 50%)}
+  50%  {color: hsl(180, 100%, 50%)}
+  60%  {color: hsl(216, 100%, 50%)}
+  70%  {color: hsl(252, 100%, 50%)}
+  80%  {color: hsl(288, 100%, 50%)}
+  90%  {color: hsl(324, 100%, 50%)}
+  100% {color: hsl(360, 100%, 50%)}
+}
+</style>
+
+# <img class="headerLogo" :src="$withBase('/assets/forks_logo-az.png')"> TachiyomiAZ
+
+<ForkButtons forkName="TachiyomiAZ" downloadForkLink="https://api.github.com/repos/az4521/TachiyomiAZ/releases/latest" downloadForkStyle="background-color:#FFCC4D;color:#000000;" githubForkLink="https://github.com/az4521/TachiyomiAZ"/>
+<div class="overflowContainer">
+  <div class="textLoop">
+    <div class="textWiggle">
+      <span class="seizureText bigText"><i>The BEST fork</i> --az4521</span>
+    </div>
+  </div>
+</div>
+
+## Introduction
+**TachiyomiAZ** is maintained by **[az4521](https://github.com/az4521)** and [Syer10](https://github.com/jobobby04).
+
+This hentai focused fork is based off of **[TachiyomiEH](/forks/TachiyomiEH)**, it has most features and fixes from **Tachiyomi**, as well as features from **[TachiyomiJ2K](/forks/TachiyomiJ2K)**. It has decided to keep the hamburger menu style of navigation, compared to the other forks that are moving to the new bottom navigation style.
+
+## Features
+**Special Sources** (integrated plus added features)
+- E-Hentai/ExHentai
+- nHentai
+- Hitomi.la
+- 8Muses
+- HBrowse
+- Perv Eden
+
+**Delegated Sources** (Sources with added features if installed)
+- Puruin
+- Tsumino
+- HentaiCafe (Foolside)
+
+**From EH:**
+- Save Searches for use later
+- AutoScroll
+- Boost Page (force redownload page)
+- Page download thread customization
+- Predownload the whole chapter while reading (Optional)
+- Retry immidently instead of wating for the rest of the preloaded pages to finish downloading
+- Customize image cache size (how much space Tachiyomi has available to store future pages)
+- Sync your favorites with your EHentai/ExHentai account
+- Batch import E-Hentai/ExHentai URLs (import single URLs by pasting them into the source search box)
+- Automatic CAPTCHA solving
+
+**From EH and fixed/changed:**
+- Auto Migration (Originally from EH, it was then improved in J2k, and we have reintegrated the J2k version)
+- Merged Sources (Merge 2 or more versions of a manga to get chapters from all of them)
+- App and notification lock with fingerprint and PIN unlock
+- Restoring backups in the background
+- Fixed Tsumino and Hitomi
+- Language filtering search options for nHentai
+- Tri-state filter when filtering in library
+- Random bugfixes
+
+**Original AZ Features:**
+- Maintained hamburger navigation
+- Grid view corner rounding configuration
+- Manga recommendations
+
+<img class="zoomable" :src="$withBase('/assets/forks_gunz-az.png')">

--- a/content/forks/TachiyomiEH.md
+++ b/content/forks/TachiyomiEH.md
@@ -1,5 +1,4 @@
 ---
-layout: ForkPage
 title: TachiyomiEH
 metaTitle: TachiyomiEH
 description: This fork adds features that enhances the hentai experience with integrations to popular sevices such as E-Hentai, nHentai and more.
@@ -14,9 +13,9 @@ meta:
 sidebar: false
 ---
 
-# <img class="headerLogo" :src="$withBase('/assets/forks_logo-eh.png')"> TachiyomiEH <Badge text="Deprecated" type="error" vertical="middle" />
+# ![Alternative text](https://tachiyomi.org/icons/logo.svg) TachiyomiEH `<Badge text="Deprecated" type="error" vertical="middle" />`
 
-<ForkButtons forkName="TachiyomiEH" downloadForkLink="https://api.github.com/repos/NerdNumber9/TachiyomiEH/releases/latest" githubForkLink="https://github.com/NerdNumber9/TachiyomiEH"/>
+`<ForkButtons forkName="TachiyomiEH" downloadForkLink="https://api.github.com/repos/NerdNumber9/TachiyomiEH/releases/latest" githubForkLink="https://github.com/NerdNumber9/TachiyomiEH"/>`
 
 ## Introduction
 **TachiyomiEH** is maintained by **[NerdNumber9](https://github.com/NerdNumber9)**.
@@ -25,7 +24,7 @@ This fork adds features that enhances the hentai experience with integrations to
 
 At the moment, it is **deprecated** as the developer does not have time to maintain it. Use [TachiyomiAZ](/forks/TachiyomiAZ) instead.
 
-<img class="zoomable" :src="$withBase('/assets/forks_banner-eh.png')"/>
+`<img class="zoomable" :src="$withBase('/assets/forks_banner-eh.png')"/>`
 
 ## Features
 ::: videolink

--- a/content/forks/TachiyomiEH.md
+++ b/content/forks/TachiyomiEH.md
@@ -1,0 +1,43 @@
+---
+layout: ForkPage
+title: TachiyomiEH
+metaTitle: TachiyomiEH
+description: This fork adds features that enhances the hentai experience with integrations to popular sevices such as E-Hentai, nHentai and more.
+lang: en-US
+meta:
+  - property: og:image
+    content: /assets/forks_logo-eh.png
+  - name: theme-color
+    content: "#2e84bf"
+  - name: msapplication-TileColor
+    content: "#2e84bf"
+sidebar: false
+---
+
+# <img class="headerLogo" :src="$withBase('/assets/forks_logo-eh.png')"> TachiyomiEH <Badge text="Deprecated" type="error" vertical="middle" />
+
+<ForkButtons forkName="TachiyomiEH" downloadForkLink="https://api.github.com/repos/NerdNumber9/TachiyomiEH/releases/latest" githubForkLink="https://github.com/NerdNumber9/TachiyomiEH"/>
+
+## Introduction
+**TachiyomiEH** is maintained by **[NerdNumber9](https://github.com/NerdNumber9)**.
+
+This fork adds features that enhances the hentai experience with integrations to popular sevices such as **E-Hentai**, **nHentai** and more.
+
+At the moment, it is **deprecated** as the developer does not have time to maintain it. Use [TachiyomiAZ](/forks/TachiyomiAZ) instead.
+
+<img class="zoomable" :src="$withBase('/assets/forks_banner-eh.png')"/>
+
+## Features
+::: videolink
+For a full list of features, visit the GitHub page.
+:::
+
+- **Sync your favorites with your EHentai/ExHentai account**
+- **Search through your favorites by tag/language/artist**
+- **Open galleries in an incognito browser window**
+- **Faster download engine in the reader**
+- **Fingerprint/PIN app lock**
+- **Batch import gallery URLs**
+  - Import single URLs by pasting them into the catalogue search box
+- **Automatic captcha solving**
+- **Open gallery URLs directly in Tachiyomi**

--- a/content/forks/TachiyomiJ2K.md
+++ b/content/forks/TachiyomiJ2K.md
@@ -1,0 +1,57 @@
+---
+layout: ForkPage
+title: TachiyomiJ2K
+metaTitle: TachiyomiJ2K
+description: This fork takes a new approach to the design of the base app along with several other enhancements.
+lang: en-US
+meta:
+  - property: og:image
+    content: /assets/forks_logo-j2k.png
+  - name: theme-color
+    content: "#2e84bf"
+  - name: msapplication-TileColor
+    content: "#2e84bf"
+sidebar: false
+---
+
+# <img class="headerLogo" :src="$withBase('/assets/forks_logo-j2k.png')"> TachiyomiJ2K
+
+<ForkButtons forkName="TachiyomiJ2K" downloadForkLink="https://api.github.com/repos/Jays2Kings/tachiyomiJ2K/releases/latest" githubForkLink="https://github.com/Jays2Kings/tachiyomiJ2K" androidVersion="6.0"/>
+
+## Introduction
+**TachiyomiJ2K** is maintained by **[Jays2Kings](https://github.com/Jays2Kings)**.
+
+This fork takes a new approach to the design of the base app along with several other enhancements.
+
+<img class="zoomable" :src="$withBase('/assets/forks_banner-j2k.png')"/>
+
+## Features
+::: videolink
+For a full list of features, visit the GitHub page.
+:::
+
+- **New Manga details screen**
+- **New Recents page**
+  - Providing quick access to newly added manga, new chapters, and to continue where you left on in a series
+- **Android 10 Edge to Edge support**
+  - No more small ugly bar for the gesture navigation.
+  - Older versions get a translucent nav bar instead.
+- **Automatic background based on manga page**
+  - For those that like having a white background to match the content, this will automatically set the background to match for moments such as a flashback section of a manga.
+- **Reader seekbar overrides switch app gesture in Android 10, so no more accidents for that**
+- **[New material snackbar](https://raw.githubusercontent.com/Jays2Kings/tachiyomi/master/.github/readme-images/material%20snackbar.png)**
+  - Removing manga now auto deletes chapters and has an undo button in case you change your mind.
+- **Library specific enhancements**
+  - Library Categories are stacked vertically
+  - Per-category/Drag & drop sorting
+  - Tri-state/Negative filters
+  - Multi-source migration
+  - Sort by Date Added (*Taken from [Neko](/forks/Neko).*)
+- **[Share sheets upgrade for Android 10](https://raw.githubusercontent.com/Jays2Kings/tachiyomi/master/.github/readme-images/share%20menu.png)**
+- **Batch Auto-Source Migration**
+  - *Taken from [TachiyomiEH](/forks/TachiyomiEH).*
+- **Recently Read goes all the way back to the beginning of time**
+- **Restoring backups in the background**
+  - *Taken from [Neko](/forks/Neko).*
+- **Expanding manga thumbnails**
+- **A lot more Material Design 2 additions**

--- a/content/forks/TachiyomiJ2K.md
+++ b/content/forks/TachiyomiJ2K.md
@@ -1,5 +1,4 @@
 ---
-layout: ForkPage
 title: TachiyomiJ2K
 metaTitle: TachiyomiJ2K
 description: This fork takes a new approach to the design of the base app along with several other enhancements.
@@ -14,16 +13,16 @@ meta:
 sidebar: false
 ---
 
-# <img class="headerLogo" :src="$withBase('/assets/forks_logo-j2k.png')"> TachiyomiJ2K
+# ![Alternative text](https://tachiyomi.org/icons/logo.svg) TachiyomiJ2K
 
-<ForkButtons forkName="TachiyomiJ2K" downloadForkLink="https://api.github.com/repos/Jays2Kings/tachiyomiJ2K/releases/latest" githubForkLink="https://github.com/Jays2Kings/tachiyomiJ2K" androidVersion="6.0"/>
+`<ForkButtons forkName="TachiyomiJ2K" downloadForkLink="https://api.github.com/repos/Jays2Kings/tachiyomiJ2K/releases/latest" githubForkLink="https://github.com/Jays2Kings/tachiyomiJ2K" androidVersion="6.0"/>`
 
 ## Introduction
 **TachiyomiJ2K** is maintained by **[Jays2Kings](https://github.com/Jays2Kings)**.
 
 This fork takes a new approach to the design of the base app along with several other enhancements.
 
-<img class="zoomable" :src="$withBase('/assets/forks_banner-j2k.png')"/>
+`<img class="zoomable" :src="$withBase('/assets/forks_banner-j2k.png')"/>`
 
 ## Features
 ::: videolink

--- a/content/forks/TachiyomiSY.md
+++ b/content/forks/TachiyomiSY.md
@@ -1,5 +1,4 @@
 ---
-layout: ForkPage
 title: TachiyomiSY
 metaTitle: TachiyomiSY
 description: This fork adds quite a few custom unique features, it also has new features from the latest Tachiyomi version as well as from other forks such as TachiyomiJ2K.
@@ -14,15 +13,15 @@ meta:
 sidebar: false
 ---
 
-# <img class="headerLogo" :src="$withBase('/assets/forks_logo-sy.png')"> TachiyomiSY
+# ![Alternative text](https://tachiyomi.org/icons/logo.svg) TachiyomiSY
 
-<ForkButtons forkName="TachiyomiSY" downloadForkLink="https://api.github.com/repos/jobobby04/TachiyomiSY/releases/latest" downloadForkStyle="background-color:#BE0F6E;color:#FFFFFF;" githubForkLink="https://github.com/jobobby04/TachiyomiSY"/>
+`<ForkButtons forkName="TachiyomiSY" downloadForkLink="https://api.github.com/repos/jobobby04/TachiyomiSY/releases/latest" downloadForkStyle="background-color:#BE0F6E;color:#FFFFFF;" githubForkLink="https://github.com/jobobby04/TachiyomiSY"/>`
 
 ## About
 This fork is based off of [TachiyomiAZ](/forks/TachiyomiAZ) and adds quite a few custom unique features, it also has new features from the latest **Tachiyomi** version as well as from other forks such as [TachiyomiJ2K](/forks/TachiyomiJ2K).
 
 ## Screenshots
-<img class="zoomable" :src="$withBase('/assets/forks_banner-sy.png')"/>
+`<img class="zoomable" :src="$withBase('/assets/forks_banner-sy.png')"/>`
 
 ## Features
 - Uses the new **Tachiyomi** UI

--- a/content/forks/TachiyomiSY.md
+++ b/content/forks/TachiyomiSY.md
@@ -1,0 +1,50 @@
+---
+layout: ForkPage
+title: TachiyomiSY
+metaTitle: TachiyomiSY
+description: This fork adds quite a few custom unique features, it also has new features from the latest Tachiyomi version as well as from other forks such as TachiyomiJ2K.
+lang: en-US
+meta:
+  - property: og:image
+    content: /assets/forks_logo-sy.png
+  - name: theme-color
+    content: "#BE0F6E"
+  - name: msapplication-TileColor
+    content: "#BE0F6E"
+sidebar: false
+---
+
+# <img class="headerLogo" :src="$withBase('/assets/forks_logo-sy.png')"> TachiyomiSY
+
+<ForkButtons forkName="TachiyomiSY" downloadForkLink="https://api.github.com/repos/jobobby04/TachiyomiSY/releases/latest" downloadForkStyle="background-color:#BE0F6E;color:#FFFFFF;" githubForkLink="https://github.com/jobobby04/TachiyomiSY"/>
+
+## About
+This fork is based off of [TachiyomiAZ](/forks/TachiyomiAZ) and adds quite a few custom unique features, it also has new features from the latest **Tachiyomi** version as well as from other forks such as [TachiyomiJ2K](/forks/TachiyomiJ2K).
+
+## Screenshots
+<img class="zoomable" :src="$withBase('/assets/forks_banner-sy.png')"/>
+
+## Features
+- Uses the new **Tachiyomi** UI
+- Enhanced pages for certain sources
+- Latest tab preview configurable to show up to five sources
+- Ability to enable and disable Hentai features
+- Automatic webtoon detection, allowing the reader to switch to webtoon mode automatically when viewing one
+- Manga recommendations from both [MyAnimeList](https://myanimelist.net/) and [AniList](https://anilist.co/)
+- Lewd filter so you can hide the lewd manga in your library if you want to
+- Tracking filter so you can filter your tracked manga
+- Search tracking status in library
+- Backup saved searches
+- New E-Hentai/ExHentai features such as language settings and watched list settings
+- Comfortable grid view
+- Source categories
+- Manga info edit
+- Enhanced views for internal and delegated sources
+- Numerous features from [TachiyomiAZ](/forks/TachiyomiAZ)
+
+## Credits
+- [She11Shocked](https://github.com/she11sh0cked/) for the extra tracking, filter, recommendation features and a ton more.
+- [az4521](https://github.com/az4521) for the base recommendations and **AZ**.
+
+## Disclaimer
+The developer of this application does not have any affiliation with the content providers available.

--- a/content/forks/index.md
+++ b/content/forks/index.md
@@ -2,6 +2,7 @@
 title: Forks
 description: Forks are alternative versions of Tachiyomi with exclusive features.
 lang: en-US
+prev: '/extensions/'
 sidebar: true
 sidebarDepth: 0
 ---
@@ -9,7 +10,7 @@ sidebarDepth: 0
 # Forks
 Forks are alternative versions of **Tachiyomi** with exclusive features.
 
-## <img class="headerLogo" :src="$withBase('/assets/forks_logo-neko.png')"> [Neko](/forks/Neko)
+## ![Alternative text](https://tachiyomi.org/icons/logo.svg) [Neko](/forks/Neko)
 ::: videolink
 Maintained by [CarlosEsco](https://github.com/CarlosEsco)
 <br>Requires Android 7.0+
@@ -20,7 +21,7 @@ Some features include:
 * Same UI and features of J2K minus editing manga/cover
 * Built in manga recommendations
 
-## <img class="headerLogo" :src="$withBase('/assets/forks_logo-j2k.png')"> [TachiyomiJ2K](/forks/TachiyomiJ2K)
+## ![Alternative text](https://tachiyomi.org/icons/logo.svg) [TachiyomiJ2K](/forks/TachiyomiJ2K)
 ::: videolink
 Maintained by [Jays2Kings](https://github.com/Jays2Kings)
 <br>Requires Android 6.0+
@@ -31,7 +32,7 @@ Some features include:
 * Dynamic Categories
 * Automatic background based on manga page
 
-## <img class="headerLogo" :src="$withBase('/assets/forks_logo-az.png')"> [TachiyomiAZ](/forks/TachiyomiAZ)
+## ![Alternative text](https://tachiyomi.org/icons/logo.svg) [TachiyomiAZ](/forks/TachiyomiAZ)
 ::: videolink
 Maintained by [az4521](https://github.com/az4521)
 <br>Requires Android 5.0+
@@ -44,7 +45,7 @@ Some features include:
 * Manga recommendations from My Anime List and AniDB
 * Grid view corner rounding configuration
 
-## <img class="headerLogo" :src="$withBase('/assets/forks_logo-sy.png')"> [TachiyomiSY](/forks/TachiyomiSY)
+## ![Alternative text](https://tachiyomi.org/icons/logo.svg) [TachiyomiSY](/forks/TachiyomiSY)
 ::: videolink
 Maintained by [Syer10](https://github.com/jobobby04)
 <br>Requires Android 5.0+

--- a/content/forks/index.md
+++ b/content/forks/index.md
@@ -1,0 +1,58 @@
+---
+title: Forks
+description: Forks are alternative versions of Tachiyomi with exclusive features.
+lang: en-US
+sidebar: true
+sidebarDepth: 0
+---
+
+# Forks
+Forks are alternative versions of **Tachiyomi** with exclusive features.
+
+## <img class="headerLogo" :src="$withBase('/assets/forks_logo-neko.png')"> [Neko](/forks/Neko)
+::: videolink
+Maintained by [CarlosEsco](https://github.com/CarlosEsco)
+<br>Requires Android 7.0+
+:::
+This **MangaDex** focused fork enhances your reading with native integration and recommendations.
+Some features include:
+* Option to merge missing chapters from another source
+* Same UI and features of J2K minus editing manga/cover
+* Built in manga recommendations
+
+## <img class="headerLogo" :src="$withBase('/assets/forks_logo-j2k.png')"> [TachiyomiJ2K](/forks/TachiyomiJ2K)
+::: videolink
+Maintained by [Jays2Kings](https://github.com/Jays2Kings)
+<br>Requires Android 6.0+
+:::
+This fork takes a new approach to the design of the base app along with several other enhancements.
+Some features include:
+* New Manga details screen and New Recents page
+* Dynamic Categories
+* Automatic background based on manga page
+
+## <img class="headerLogo" :src="$withBase('/assets/forks_logo-az.png')"> [TachiyomiAZ](/forks/TachiyomiAZ)
+::: videolink
+Maintained by [az4521](https://github.com/az4521)
+<br>Requires Android 5.0+
+:::
+
+This hentai focused fork is based on **[TachiyomiEH](/forks/TachiyomiEH)**, it has most features and fixes from **Tachiyomi**, as well as features from **[TachiyomiJ2K](/forks/TachiyomiJ2K)**. It has decided to keep the old hamburger menu style of navigation, compared to the other forks that have moved to the new bottom navigation style.
+
+Some features include:
+* Built in sources of many popular hentai sources with additional features.
+* Manga recommendations from My Anime List and AniDB
+* Grid view corner rounding configuration
+
+## <img class="headerLogo" :src="$withBase('/assets/forks_logo-sy.png')"> [TachiyomiSY](/forks/TachiyomiSY)
+::: videolink
+Maintained by [Syer10](https://github.com/jobobby04)
+<br>Requires Android 5.0+
+:::
+
+This fork is based on [TachiyomiAZ](/forks/TachiyomiAZ) and adds quite a lot of unique features. It has the same new UI as the latest Tachiyomi version. And at the same time, it also shares quite a lot of features from both **Tachiyomi** and [TachiyomiJ2K](/forks/TachiyomiJ2K).
+
+Some features include:
+* Enhanced pages for certain sources
+* Latest tab preview configurable up to five sources
+* Ability to enable and disable hentai specific features

--- a/content/help/contribution.md
+++ b/content/help/contribution.md
@@ -1,0 +1,52 @@
+---
+title: Contribution
+description: Find out how to help translate or build the app and extensions.
+lang: en-US
+---
+
+# Contribution
+Find out how to help translate or build the app and extensions.
+
+## Code
+Skilled at code? Know how to improve something or you generally want to support the creation of the app?
+
+### Application
+The main application.
+- Current: [inorichi/tachiyomi](https://github.com/inorichi/tachiyomi) ![GitHub issues](https://img.shields.io/github/issues/inorichi/tachiyomi?style=social)
+- Rewrite project: [tachiyomiorg/android-app](https://github.com/tachiyomiorg/android-app) ![GitHub issues](https://img.shields.io/github/issues/tachiyomiorg/android-app?style=social)
+***
+### Extensions
+Used to read from different manga services.
+- Current: [inorichi/tachiyomi-extensions](https://github.com/inorichi/tachiyomi-extensions) ![GitHub issues](https://img.shields.io/github/issues/inorichi/tachiyomi-extensions?style=social)
+- Rewrite project: [tachiyomiorg/extensions](https://github.com/tachiyomiorg/extensions) ![GitHub issues](https://img.shields.io/github/issues/tachiyomiorg/extensions?style=social)
+***
+### Website
+The repository that hosts this very website you're reading on now.
+- [tachiyomiorg/website](https://github.com/tachiyomiorg/website) ![GitHub issues](https://img.shields.io/github/issues/tachiyomiorg/website?style=social)
+
+## Translation
+<a href="https://hosted.weblate.org/engage/tachiyomi/?utm_source=widget"><img src="https://hosted.weblate.org/widgets/tachiyomi/-/svg-badge.svg" alt="Translation status"/></a>
+
+Want to help translate the app to your language? You can easily help by utilizing a service we use called **Weblate**.
+
+Visit our translation project [here](https://hosted.weblate.org/projects/tachiyomi/strings/).
+
+#### Helpful links
+***
+* [Translators guide](https://docs.weblate.org/en/latest/user/translating.html)
+* [Secondary-languages](https://docs.weblate.org/en/latest/user/profile.html#secondary-languages)
+* [Subscriptions](https://docs.weblate.org/en/latest/user/profile.html#subscriptions)
+* [Glossary](https://docs.weblate.org/en/latest/user/translating.html#glossary)
+
+#### Project status
+***
+<a href="https://hosted.weblate.org/engage/tachiyomi/?utm_source=widget">
+	<img src="https://hosted.weblate.org/widgets/tachiyomi/-/horizontal-auto.svg" alt="Translation status" />
+</a>
+
+## Donation
+If you can't contribute code or translations but you still wish to help, then you can choose to contribute directly to the projects founder, [Inorichi](https://github.com/inorichi/) by using the button below, or going [directly to Ko-Fi](https://ko-fi.com/inorichi).
+***
+<a href="https://ko-fi.com/inorichi" target="_blank" rel="noopener">
+	<img height="36" style="border:0px;height:36px;" src="https://cdn.ko-fi.com/cdn/kofi1.png?v=2" border="0" alt="Buy Me a Coffee at ko-fi.com" />
+</a>

--- a/content/help/faq/index.md
+++ b/content/help/faq/index.md
@@ -1,0 +1,313 @@
+---
+title: Frequently Asked Questions
+description: Need help with something? Most of your issues can probably be solved from this page.
+lang: en-US
+sidebarDepth: 2
+---
+
+# Frequently Asked Questions
+
+## Application
+
+### Library
+
+#### How can I see how many chapters I've downloaded?
+This can be done by enabling **Download badges** under <Navigation item="library"/>.
+
+::: guide
+Enable it by going to <Navigation item="library"/> → <Navigation item="filter"/> → **Display** section and then checking the **Download badges** option at the bottom.
+:::
+
+#### Why are some covers white after restoring from backup?
+The URL to the cover has probably changed. To fix this, refresh the metadata of your library.
+
+::: guide
+Refresh your metadata by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> then pressing **Refresh library metadata**.
+:::
+
+#### How do I ignore chapters from certain scanlator groups?
+Every now and then you find a manga that is translated by more than one group. Because of this, you get multiple releases for each chapter in the manga. The easiest way to fix this is to change sorting to **Total chapters**. You won't see any changes but, when you start reading you'll automatically skip the duplicate releases.
+
+::: guide
+Change library sorting by going to <Navigation item="library"/> → <Navigation item="filter"/> → **Sort** section then in this case selecting **Total chapters**.
+:::
+
+### Browse
+
+#### Why can't I find X manga?
+Sometimes you can struggle to find a source hosting the manga you're looking for, look here for some tips to help you find it.
+::: guide Tips to find your manga
+1. Look up the title on [Google](https://google.com/) or a manga database such as [MangaUpdates](https://www.mangaupdates.com/).
+1. See if a website or scanlator has the series, then check the [Extensions](/extensions/) list.
+
+#### If you found the website/scanlator in the list
+Download the corresponding extension, go to the source, then search for the manga there.
+#### If you didn't find the website/scanlator in the list
+If you found a website or scanlator that hosts your manga but doesn't exist as a source or extension, then you can see if its [already been requested](https://github.com/inorichi/tachiyomi-extensions/issues) or you can [request it yourself](https://github.com/inorichi/tachiyomi-extensions/issues/new/choose).
+
+If the website/scanlator group doesn't have an online manga reader, you can download the manga manually and set up [local manga](/help/guides/reading-local-manga).
+:::
+
+### Reader
+#### Why are some images not displayed?
+Aside from network issues, it could be because the images are too big or that the decoder doesn't support that image type.
+
+### Downloads
+#### What happened to the simultaneous downloads feature?
+It was removed to prevent IP bans caused by too many requests. We know that speed is being sacrificed but it's better than not being able to access a source at all.
+
+#### Why are Downloads unstable?
+Be aware that it could be a network issue on your device or on the catalog you are trying to download from.
+
+#### Can you make it possible to store manga on both internal storage and external SD-card?
+At the moment, no. You could try using symlinks but that requires having your phone rooted.
+::: note
+Read more about rooting your phone [here](https://www.xda-developers.com/root/)
+:::
+
+### Tracking
+#### How do I log in with Kitsu?
+To log in with Kitsu you need to use your email address as your username.
+
+#### Why can't I find manga in MAL's search results?
+You can search a manga from your MAL profile's list by searching in the following format: `my:<manga>`
+::: note
+Related GitHub issue: [#65](https://github.com/inorichi/tachiyomi/issues/65)
+:::
+
+### Local Manga
+#### How do I import my manga into Tachiyomi?
+We recommend you to read [this](/help/guides/reading-local-manga) guide on how to do so.
+
+#### What do I do if I can't find the Tachiyomi folder?
+If you don't see a **Tachiyomi** folder on your device, try downloading a chapter of any manga or creating a backup so that the folder can be created.
+
+### Application Updates
+#### How do I enable automatic updates?
+From version **0.9.0** and onwards, Tachiyomi has automatic updates for the app enabled by default. The **Preview** version also has automatic updates enabled by default.
+
+However, if you think you are on an outdated version, go to <Navigation item="more"/> → <Navigation item="about"/> → and click on **Check for updates**.
+
+#### Why are automatic updates not working?
+
+Certain devices such as MIUI have very aggressive battery saving, which can kill the app in the background. To whitelist Tachiyomi from battery saver, go to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> and click on **Disable battery optimization**.
+
+### User Interface
+#### Can I change the app language?
+**Tachiyomi** is translated in 40+ different languages. By default, the app follows the language used on your device.
+Only the UI has been localized, the language of the manga will still be using the language of the source selected.
+
+::: guide
+You can change language by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_general"/> then pressing **Language**.
+:::
+
+### Miscellaneous
+
+#### What is Tachiyomi Preview?
+It's a weekly updated version of the app. It contains features that can be added to Tachiyomi in the future, but there is a higher chance for bugs. Tachiyomi Preview is used by developers and contributors to test the app and find bugs.
+
+If you are willing to use Tachiyomi Preview, be sure to [turn on auto-backup](/help/guides/creating-backups/#turning-on-auto-backups) to prevent losing your library due to potential bugs.
+
+#### Why can't I uninstall Tachiyomi?
+
+On **Android 10**, a bug was introduced which prevented users from uninstalling the app if the phone had a MicroSD card. To fix the issue, please remove the MicroSD card from the phone first, then uninstall Tachiyomi.
+
+#### Will there be an iOS version?
+There is no iOS version and no plans for one. Since iOS and Android apps don't share code it's hard to port.
+
+#### Will Tachiyomi ever be on the Google Play Store?
+Due to Google Play's content policy, almost certainly not, as they do not allow the APK system to work. The content on some sites will lead to Google taking it down at some point, and Inorichi does not want to have to deal with it as they have stated [before](https://github.com/inorichi/tachiyomi/issues/1745#issuecomment-441208074)
+
+#### How can I report Tachiyomi copycats on the Google Play Store?
+If you're on desktop, fill out [this](https://support.google.com/googleplay/android-developer/contact/takedown) form following [these](https://pastebin.com/08eeuJxH) steps.
+
+#### Can Tachiyomi read Light Novels?
+No. Tachiyomi is an image parser, meaning it can't parse text.
+
+#### Can I revert back from the Material Design 2 update of Tachiyomi?
+While there will never be a toggle between the two UI versions, you can continue to use the old UI version by using [TachiyomiAZ](https://tachiyomi.org/forks/TachiyomiAZ/).
+
+#### Will there ever be a dual-page reader option?
+The logic required to make a dual-page reader automatically work along with scanlator page inconsistencies and other issues means it is unlikely to be added at this time.
+
+#### I see manga images in my phone gallery, what gives!?
+Tachiyomi by default adds a `.nomedia` file to prevent this from happening but sometimes it doesn't work or something went wrong. To fix this, all you need to do is create the file yourself. Name it `.nomedia` and place it in your download folder.
+
+#### I lost everything, what now?
+To avoid data loss in the future, you can use the automatic backup feature.
+
+::: note
+Learn how to create automatic backups [here](/help/guides/creating-backups/#turning-on-auto-backups/)
+:::
+
+## Extensions
+
+### General
+
+#### What are some recommended extensions?
+Tachiyomi does not endorse or recommend any manga source, and there is no best extension. Rather, we encourage users to spend some time to try out a few sources themselves, and discover what sources work best for them. It's because what works well for somebody else, might not work well for you.
+
+<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>
+
+#### What are scanlator sources?
+Manga that are not officially licensed are translated by scanlators, who either publish manga on their own website or **MangaDex**. Scanlator sources always provide the fastest manga updates and have the highest scan quality.
+
+Some popular scanlator sources are  **MerakiScans**, **Hatigarm Scans** and **Leviatan Scans**. (in **Genkan** extension)
+
+Learn more about scanlation in this **Wikipedia** [**article**](https://en.wikipedia.org/wiki/Scanlation).
+
+#### Which sources are in the multi-source extensions?
+Some extensions contain multiple sources, look at the list below to find out which extension to install for the specific source that you want.
+
+::: guide
+User [SnakeDoc83](https://github.com/snakedoc83) has made a handy spreadsheet showing the different multi-source extensions and their sources.
+::: note
+Access the spreadsheet [here](https://tachiyomi.org/extensions-spreadsheet)
+:::
+
+#### How do I request a new extension?
+Open an issue [on GitHub](https://github.com/inorichi/tachiyomi-extensions/issues) if one does not already exist.
+
+::: note
+You can find the list of extensions to download [here](/extensions/)
+:::
+
+#### Why won't the extensions install?
+In some cases your phone might have some issues downloading the extensions, in those cases you can try installing them yourselves directly from the source.
+
+To install just download the file for the extension you want and then install it, like how you installed **Tachiyomi**.
+
+#### How do I allow third-party installations?
+::::: el-tabs
+:::: el-tab-pane label="Android 8.0 and higher"
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for Android 8.0 and newer video guide](/assets/faq_unknown-sources-a10.webm)
+:::
+When installing your first extension and are prompted that your phone *isn't allowed* to install unknown apps from that source, simply follow the prompt to allow it.
+
+In *newer* versions of **Android** you need to enable **Install unknown apps** by a per-app basis.
+::::
+:::: el-tab-pane label="Android 7.1 and lower"
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for Android 7.1 and older video guide](/assets/faq_unknown-sources-a7.webm)
+:::
+When installing your first extension and are prompted that your phone *isn't allowed* to install unknown apps from that source, simply follow the prompt to allow it.
+
+In *older* versions of **Android** you only need to enable **Unknown sources** globally.
+::::
+:::::
+
+::: note
+If you need more help regarding this, read [this](https://www.theandroidsoul.com/how-to-allow-apps-installation-from-unknown-sources-on-android-9-pie/)
+:::
+
+#### How do I uninstall an extension?
+Extensions for **Tachiyomi** are technically installed the same as normal apps. Either you uninstall them through the app section on your phone's settings or you go can do it in the app.
+
+::: guide
+To uninstall an extension from within **Tachiyomi**, go to <Navigation item="browse"/> → **Extensions** then tap **Uninstall** on the extension you want to remove.
+:::
+
+#### Why don't I have extensions or any sources in Browse?
+- **Tachiyomi** no longer have pre-installed extensions, this means that you will need to install extensions you want to use from the <Navigation item="browse"/> → **Extensions** menu.
+- If you're getting the `Loader not implemented` error after clicking on a manga, you will need to reinstall the extensions you used to use.
+
+#### How do see sources of other languages?
+
+You do this by following the steps below.
+
+1. Go to <Navigation item="browse"/> → **Sources**.
+1. Click on <Navigation item="filter"/> on the top right corner.
+1. Scroll down until you find the language of your source and enable it.
+
+#### Why can't I restore my backup?
+To restore backups, **Tachiyomi** requires to have extensions installed for the respective manga you want to restore.
+
+
+#### Why can't I find manga when searching Browse?
+It might be because the title is worded differently. Follow any of the steps below:
+- Look up the title on a search engine like **Google** or a manga tracking service such as [AniList](https://anilist.co/home).
+- See which site has the series, often a single source will not satisfy all your needs.
+- Download the extension for that source from <Navigation item="browse"/> → **Extensions** if it exists, read [this](/help/faq/#which-sources-are-in-the-multi-source-extensions) for a list of which extensions contains what sources.
+- Go to <Navigation item="browse"/> and tap on a source then search for the manga again.
+
+### MangaDex
+
+#### Why are there no results when searching?
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/faq_mangadex-no-results.mp4)
+:::
+
+If you're not getting any results when searching **MangaDex** then you need to log in. To do so enter the <Navigation item="webview"/> for **MangaDex** then press the **Manga** drop-down and choose either **Sign up** or **Log in** to proceed with the login.
+
+::: guide
+To enter the **WebView** go to <Navigation item="browse"/> → <Navigation item="button_latest"/> next to **MangaDex**, then press on <Navigation item="webview"/> in the top right corner.
+:::
+
+#### Why is MangaDex slow?
+If pages are loading slowly or not at all, try:
+- Making sure you have the *latest* version of the extension.
+- Checking if **MangaDex** is either down, or is having the same issues.
+- Trying to **Clear database** under <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>.
+- Trying to **Clear chapter cache** under <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>.
+- Going to <Navigation item="browse"/> → <Navigation item="extensions"/> → **MangaDex** → **Image Server** and then selecting a *different* server location.
+
+<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>
+
+#### Is there an alternate searching method?
+**MangaDex** allows you to search using the ID number to find manga. The easiest way to get the ID is by opening the manga in your browser and looking at the URL.
+
+::: guide
+An example search would be **`id:23427`** which would return results for [Candy & Cigarettes](https://mangadex.org/title/23427/candy-cigarettes)
+:::
+
+#### How do I deal with duplicate chapters in MangaDex?
+This can be solved by opening **MangaDex** in <Navigation item="webview"/> and block the scanlator group whose chapter you don't want to see.
+
+#### How do I fix chapters from Mangaplus being broken?
+Install the **MANGA Plus by SHUEISHA** extension instead and then migrate the manga that uses **MANGA Plus** on **MangaDex** onto the **MANGA Plus** source.
+
+::: note
+Read about source migration [here](/help/guides/source-migration/)
+:::
+
+### MangaPark
+
+#### How do I deal with duplicate chapters in MangaPark?
+To solve this issue, follow the below steps.
+
+1. Go to <Navigation item="browse"/> → <Navigation item="extensions"/>.
+1. Click on **MangaPark** extension and then **Chapter List Source**.
+1. Choose an option like **Smart list** or **Prioritize source**.
+1. Go back to **MangaPark**'s chapter list and refresh it.
+
+### Mangabox
+
+#### What does `Page list is empty` mean?
+**Mangakakalot**/**Manganelo** have created new entries for manga on their sites again. Some old entries are obsolete and will not work. To resolve this, [migrate](/help/guides/source-migration/#source-migration) the manga from **Mangakakalot**/**Manganelo** to another source.
+
+#### What does `Source URL has changed` mean?
+This means that the manga is dead and needs to be migrated from **Mangakakalot**/**Manganelo** to a different source. Refer to the guide for **Page list is empty** above.
+
+#### How do I fix the `Image could not be decoded` error?
+Open the manga in WebView and wait for the image to comes up. If the image isn't loading you will need to look elsewhere to read that particular manga, as some Mangabox sources, such as Mangakakalot, are now blocking entire regions.
+
+### Webtoons.com
+
+#### How do I fix the `Page list is empty` error?
+You will have to open the manga entry in WebView and verify your age, as Webtoons has recently added age verifications on their site.
+
+### Japscan
+
+#### Why are some Japscan chapters not loading?
+Japscan has some manga that are scrambled using a different algorithm than others on their site. If you encounter a manga being scrambled, use a different source to read.
+
+### KissManga and MangaRock
+:::: el-collapse
+::: el-collapse-item title="Where is KissManga?"
+**KissManga** went under permanently in August 2020, we will not add something that doesn't exist back..
+:::
+::: el-collapse-item title="Where is MangaRock"
+**MangaRock** converted from a piracy app and went legit, they are now called **INKR** but is nowhere near what they were before.
+:::
+::::

--- a/content/help/faq/index.md
+++ b/content/help/faq/index.md
@@ -12,24 +12,24 @@ sidebarDepth: 2
 ### Library
 
 #### How can I see how many chapters I've downloaded?
-This can be done by enabling **Download badges** under <Navigation item="library"/>.
+This can be done by enabling **Download badges** under `<Navigation item="library"/>`.
 
 ::: guide
-Enable it by going to <Navigation item="library"/> → <Navigation item="filter"/> → **Display** section and then checking the **Download badges** option at the bottom.
+Enable it by going to `<Navigation item="library"/>` → `<Navigation item="filter"/>` → **Display** section and then checking the **Download badges** option at the bottom.
 :::
 
 #### Why are some covers white after restoring from backup?
 The URL to the cover has probably changed. To fix this, refresh the metadata of your library.
 
 ::: guide
-Refresh your metadata by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> then pressing **Refresh library metadata**.
+Refresh your metadata by going to `<Navigation item="more"/>` → `<Navigation item="settings"/>` → `<Navigation item="settings_advanced"/>` then pressing **Refresh library metadata**.
 :::
 
 #### How do I ignore chapters from certain scanlator groups?
 Every now and then you find a manga that is translated by more than one group. Because of this, you get multiple releases for each chapter in the manga. The easiest way to fix this is to change sorting to **Total chapters**. You won't see any changes but, when you start reading you'll automatically skip the duplicate releases.
 
 ::: guide
-Change library sorting by going to <Navigation item="library"/> → <Navigation item="filter"/> → **Sort** section then in this case selecting **Total chapters**.
+Change library sorting by going to `<Navigation item="library"/>` → `<Navigation item="filter"/>` → **Sort** section then in this case selecting **Total chapters**.
 :::
 
 ### Browse
@@ -86,11 +86,11 @@ If you don't see a **Tachiyomi** folder on your device, try downloading a chapte
 #### How do I enable automatic updates?
 From version **0.9.0** and onwards, Tachiyomi has automatic updates for the app enabled by default. The **Preview** version also has automatic updates enabled by default.
 
-However, if you think you are on an outdated version, go to <Navigation item="more"/> → <Navigation item="about"/> → and click on **Check for updates**.
+However, if you think you are on an outdated version, go to `<Navigation item="more"/>` → `<Navigation item="about"/>` → and click on **Check for updates**.
 
 #### Why are automatic updates not working?
 
-Certain devices such as MIUI have very aggressive battery saving, which can kill the app in the background. To whitelist Tachiyomi from battery saver, go to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> and click on **Disable battery optimization**.
+Certain devices such as MIUI have very aggressive battery saving, which can kill the app in the background. To whitelist Tachiyomi from battery saver, go to `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>` and click on **Disable battery optimization**.
 
 ### User Interface
 #### Can I change the app language?
@@ -98,7 +98,7 @@ Certain devices such as MIUI have very aggressive battery saving, which can kill
 Only the UI has been localized, the language of the manga will still be using the language of the source selected.
 
 ::: guide
-You can change language by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_general"/> then pressing **Language**.
+You can change language by going to `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_general"/>` then pressing **Language**.
 :::
 
 ### Miscellaneous
@@ -147,7 +147,7 @@ Learn how to create automatic backups [here](/help/guides/creating-backups/#turn
 #### What are some recommended extensions?
 Tachiyomi does not endorse or recommend any manga source, and there is no best extension. Rather, we encourage users to spend some time to try out a few sources themselves, and discover what sources work best for them. It's because what works well for somebody else, might not work well for you.
 
-<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>
+`<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>`
 
 #### What are scanlator sources?
 Manga that are not officially licensed are translated by scanlators, who either publish manga on their own website or **MangaDex**. Scanlator sources always provide the fastest manga updates and have the highest scan quality.
@@ -205,19 +205,19 @@ If you need more help regarding this, read [this](https://www.theandroidsoul.com
 Extensions for **Tachiyomi** are technically installed the same as normal apps. Either you uninstall them through the app section on your phone's settings or you go can do it in the app.
 
 ::: guide
-To uninstall an extension from within **Tachiyomi**, go to <Navigation item="browse"/> → **Extensions** then tap **Uninstall** on the extension you want to remove.
+To uninstall an extension from within **Tachiyomi**, go to `<Navigation item="browse"/>` → **Extensions** then tap **Uninstall** on the extension you want to remove.
 :::
 
 #### Why don't I have extensions or any sources in Browse?
-- **Tachiyomi** no longer have pre-installed extensions, this means that you will need to install extensions you want to use from the <Navigation item="browse"/> → **Extensions** menu.
+- **Tachiyomi** no longer have pre-installed extensions, this means that you will need to install extensions you want to use from the `<Navigation item="browse"/>` → **Extensions** menu.
 - If you're getting the `Loader not implemented` error after clicking on a manga, you will need to reinstall the extensions you used to use.
 
 #### How do see sources of other languages?
 
 You do this by following the steps below.
 
-1. Go to <Navigation item="browse"/> → **Sources**.
-1. Click on <Navigation item="filter"/> on the top right corner.
+1. Go to `<Navigation item="browse"/>` → **Sources**.
+1. Click on `<Navigation item="filter"/>` on the top right corner.
 1. Scroll down until you find the language of your source and enable it.
 
 #### Why can't I restore my backup?
@@ -228,31 +228,31 @@ To restore backups, **Tachiyomi** requires to have extensions installed for the 
 It might be because the title is worded differently. Follow any of the steps below:
 - Look up the title on a search engine like **Google** or a manga tracking service such as [AniList](https://anilist.co/home).
 - See which site has the series, often a single source will not satisfy all your needs.
-- Download the extension for that source from <Navigation item="browse"/> → **Extensions** if it exists, read [this](/help/faq/#which-sources-are-in-the-multi-source-extensions) for a list of which extensions contains what sources.
-- Go to <Navigation item="browse"/> and tap on a source then search for the manga again.
+- Download the extension for that source from `<Navigation item="browse"/>` → **Extensions** if it exists, read [this](/help/faq/#which-sources-are-in-the-multi-source-extensions) for a list of which extensions contains what sources.
+- Go to `<Navigation item="browse"/>` and tap on a source then search for the manga again.
 
 ### MangaDex
 
 #### Why are there no results when searching?
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/faq_mangadex-no-results.mp4)
+`<MaterialIcon icon="videocam"/>` [ Click for video guide](/assets/faq_mangadex-no-results.mp4)
 :::
 
-If you're not getting any results when searching **MangaDex** then you need to log in. To do so enter the <Navigation item="webview"/> for **MangaDex** then press the **Manga** drop-down and choose either **Sign up** or **Log in** to proceed with the login.
+If you're not getting any results when searching **MangaDex** then you need to log in. To do so enter the `<Navigation item="webview"/>` for **MangaDex** then press the **Manga** drop-down and choose either **Sign up** or **Log in** to proceed with the login.
 
 ::: guide
-To enter the **WebView** go to <Navigation item="browse"/> → <Navigation item="button_latest"/> next to **MangaDex**, then press on <Navigation item="webview"/> in the top right corner.
+To enter the **WebView** go to `<Navigation item="browse"/> → <Navigation item="button_latest"/>` next to **MangaDex**, then press on `<Navigation item="webview"/>` in the top right corner.
 :::
 
 #### Why is MangaDex slow?
 If pages are loading slowly or not at all, try:
 - Making sure you have the *latest* version of the extension.
 - Checking if **MangaDex** is either down, or is having the same issues.
-- Trying to **Clear database** under <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>.
-- Trying to **Clear chapter cache** under <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>.
-- Going to <Navigation item="browse"/> → <Navigation item="extensions"/> → **MangaDex** → **Image Server** and then selecting a *different* server location.
+- Trying to **Clear database** under `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>`.
+- Trying to **Clear chapter cache** under `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>`.
+- Going to `<Navigation item="browse"/> → <Navigation item="extensions"/>` → **MangaDex** → **Image Server** and then selecting a *different* server location.
 
-<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>
+`<ElAlert type="info" title="Disclaimer" description="Tachiyomi is not hosting any content, we are not affiliated with or responsible for any source that is; slow, down, missing chapters, or has subpar image quality." show-icon :closable="false"></ElAlert>`
 
 #### Is there an alternate searching method?
 **MangaDex** allows you to search using the ID number to find manga. The easiest way to get the ID is by opening the manga in your browser and looking at the URL.
@@ -262,7 +262,7 @@ An example search would be **`id:23427`** which would return results for [Candy 
 :::
 
 #### How do I deal with duplicate chapters in MangaDex?
-This can be solved by opening **MangaDex** in <Navigation item="webview"/> and block the scanlator group whose chapter you don't want to see.
+This can be solved by opening **MangaDex** in `<Navigation item="webview"/>` and block the scanlator group whose chapter you don't want to see.
 
 #### How do I fix chapters from Mangaplus being broken?
 Install the **MANGA Plus by SHUEISHA** extension instead and then migrate the manga that uses **MANGA Plus** on **MangaDex** onto the **MANGA Plus** source.
@@ -276,7 +276,7 @@ Read about source migration [here](/help/guides/source-migration/)
 #### How do I deal with duplicate chapters in MangaPark?
 To solve this issue, follow the below steps.
 
-1. Go to <Navigation item="browse"/> → <Navigation item="extensions"/>.
+1. Go to `<Navigation item="browse"/> → <Navigation item="extensions"/>`.
 1. Click on **MangaPark** extension and then **Chapter List Source**.
 1. Choose an option like **Smart list** or **Prioritize source**.
 1. Go back to **MangaPark**'s chapter list and refresh it.

--- a/content/help/guides/categories.md
+++ b/content/help/guides/categories.md
@@ -15,7 +15,7 @@ You can even add your bookmarked manga in multiple categories and can easily con
 To create a category, follow the steps below.
 
 ::: guide
-1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Go to `<Navigation item="more"/> → <Navigation item="categories"/>`.
 1. Press the **+ Add**  button in the bottom right.
 1. Enter a name and press **OK**.
 :::
@@ -25,20 +25,20 @@ To create a category, follow the steps below.
 To edit a category follow the steps below.
 
 ::: guide
-1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Go to `<Navigation item="more"/> → <Navigation item="categories"/>`.
 1. Long press a category.
-1. Tap <Navigation item="edit"/> on the top-right.
+1. Tap `<Navigation item="edit"/>` on the top-right.
 :::
 
 ## Change category order
 
-You can change the order of Categories, such as bringing a certain Category to the top. This category will appear as the first tab on <Navigation item="library"/>.
+You can change the order of Categories, such as bringing a certain Category to the top. This category will appear as the first tab on `<Navigation item="library"/>`.
 
 To do this, follow the steps below.
 
 ::: guide
-1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
-1. Drag the category to your prefered position using the <Navigation item="reorder"/> icon.
+1. Go to `<Navigation item="more"/> → <Navigation item="categories"/>`.
+1. Drag the category to your prefered position using the `<Navigation item="reorder"/>` icon.
 :::
 
 ## Delete a category
@@ -46,37 +46,37 @@ To do this, follow the steps below.
 To delete a category, follow the steps below.
 
 ::: guide
-1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Go to `<Navigation item="more"/> → <Navigation item="categories"/>`.
 1. Long press a category.
-1. Tap <Navigation item="delete"/> on the top-right.
+1. Tap `<Navigation item="delete"/>` on the top-right.
 :::
 
 ## Add manga to category
 
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_category-add-to.webm)
+`<MaterialIcon icon="videocam"/>` [Click for video guide](/assets/guides_category-add-to.webm)
 :::
 
 To add manga to a category, follow the steps below.
 
 ::: guide
 1. Long press the manga you want to add.
-2. Press the <Navigation item="set_categories"/> button.
+2. Press the `<Navigation item="set_categories"/>` button.
 3. Select which category or categories you want it in and press **OK**.
-	> You can also add multiple manga to a category by selecting them when you see the <Navigation item="set_categories"/> button.
+	> You can also add multiple manga to a category by selecting them when you see the `<Navigation item="set_categories"/>` button.
 :::
 
 ## Remove manga from category
 
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_category-remove-from.webm)
+`<MaterialIcon icon="videocam"/>` [Click for video guide](/assets/guides_category-remove-from.webm)
 :::
 
 To remove manga from a category, follow the steps below.
 
 ::: guide
 1. Long press the manga that you want to remove.
-1. Press the <Navigation item="set_categories"/> button.
+1. Press the `<Navigation item="set_categories"/>` button.
 1. Deselect the category or categories you want to remove it from and press **OK**.
-	> You can also remove multiple manga from a category by selecting them when you see the <Navigation item="set_categories"/> button.
+	> You can also remove multiple manga from a category by selecting them when you see the `<Navigation item="set_categories"/>` button.
 :::

--- a/content/help/guides/categories.md
+++ b/content/help/guides/categories.md
@@ -1,0 +1,82 @@
+---
+title: Categories
+description: Store your manga in custom categories, which help you keep your library neat and organized.
+lang: en-US
+---
+
+# Categories
+
+**Categories** help you store your bookmarked manga in custom tabs, which keeps your library neat and organized. You can name and sort them however you want according to your preference (ie. _Genre_, _Reading Status_, etc).
+
+You can even add your bookmarked manga in multiple categories and can easily control the update options through Library settings and automatically download new manga chapters from certain categories (if **Download new chapters** option is enabled in **Downloads** settings).
+
+## Create a category
+
+To create a category, follow the steps below.
+
+::: guide
+1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Press the **+ Add**  button in the bottom right.
+1. Enter a name and press **OK**.
+:::
+
+## Edit a category
+
+To edit a category follow the steps below.
+
+::: guide
+1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Long press a category.
+1. Tap <Navigation item="edit"/> on the top-right.
+:::
+
+## Change category order
+
+You can change the order of Categories, such as bringing a certain Category to the top. This category will appear as the first tab on <Navigation item="library"/>.
+
+To do this, follow the steps below.
+
+::: guide
+1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Drag the category to your prefered position using the <Navigation item="reorder"/> icon.
+:::
+
+## Delete a category
+
+To delete a category, follow the steps below.
+
+::: guide
+1. Go to <Navigation item="more"/> → <Navigation item="categories"/>.
+1. Long press a category.
+1. Tap <Navigation item="delete"/> on the top-right.
+:::
+
+## Add manga to category
+
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_category-add-to.webm)
+:::
+
+To add manga to a category, follow the steps below.
+
+::: guide
+1. Long press the manga you want to add.
+2. Press the <Navigation item="set_categories"/> button.
+3. Select which category or categories you want it in and press **OK**.
+	> You can also add multiple manga to a category by selecting them when you see the <Navigation item="set_categories"/> button.
+:::
+
+## Remove manga from category
+
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_category-remove-from.webm)
+:::
+
+To remove manga from a category, follow the steps below.
+
+::: guide
+1. Long press the manga that you want to remove.
+1. Press the <Navigation item="set_categories"/> button.
+1. Deselect the category or categories you want to remove it from and press **OK**.
+	> You can also remove multiple manga from a category by selecting them when you see the <Navigation item="set_categories"/> button.
+:::

--- a/content/help/guides/creating-backups.md
+++ b/content/help/guides/creating-backups.md
@@ -16,15 +16,15 @@ Backups can hold the following information:
 1. **Reading history**
 
 ::: guide
-You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/> and then selecting **Create backup** and select a location to save it.
+You can do this by going to `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/>` and then selecting **Create backup** and select a location to save it.
 :::
 
 ## Restoring
 
-Restoring is done from the <Navigation item="settings_backup"/> settings. To restore without issues be sure to:
+Restoring is done from the `<Navigation item="settings_backup"/>` settings. To restore without issues be sure to:
 
-* Install all the <Navigation item="tab_extensions"/> that were installed at the time of the backup.
-* Log into the <Navigation item="settings_tracking"/> services that you use.
+* Install all the `<Navigation item="tab_extensions"/>` that were installed at the time of the backup.
+* Log into the `<Navigation item="settings_tracking"/>` services that you use.
 * Log into **MangaDex** using **WebView** [as explained here](/help/faq/#no-results-when-searching).
 * You're able to access all the sources through the **WebView**.
 * Be on a consistent internet connection.
@@ -34,7 +34,7 @@ Restoring is done from the <Navigation item="settings_backup"/> settings. To res
 You can transfer downloaded manga chapters from one version of **Tachiyomi** to another.
 
 ::: guide
-You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_downloads"/> and then set the download directory to that of the download folder of your old **Tachiyomi**, then restore the backup.
+You can do this by going to `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_downloads"/>` and then set the download directory to that of the download folder of your old **Tachiyomi**, then restore the backup.
 :::
 
 ## Turning on auto-backups
@@ -42,18 +42,18 @@ You can do this by going to <Navigation item="more"/> → <Navigation item="sett
 It is highly recommended you turn on auto backups, this will ensure you can recover if need be.
 
 ::: guide
-You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/> and then setting a **backup frequency**. In the case of a catastrophic failure, at least you will be able to recover.
+You can do this by going to `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/>` and then setting a **backup frequency**. In the case of a catastrophic failure, at least you will be able to recover.
 :::
 
 ## Forks information
 
-### <img class="forkIconBefore" src="/assets/forks_logo-neko.png" width="24" height="24" /> [Neko](/forks/Neko)
+### ![Alternative text](https://tachiyomi.org/icons/logo.svg) [Neko](/forks/Neko)
 
 This fork can only restore **MangaDex** entries in a backup. If there are entries from other sources that are a part of that backup then they will not transfer.
 
-### <img class="forkIconBefore" src="/assets/forks_logo-az.png" width="24" height="24" /> [TachiyomiAZ](/forks/TachiyomiAZ), <img class="forkIconBefore" src="/assets/forks_logo-sy.png" width="24" height="24" />  [TachiyomiSY](/forks/TachiyomiSY) and <img class="forkIconBefore" src="/assets/forks_logo-eh.png" width="24" height="24" />  [TachiyomiEH](/forks/TachiyomiEH)
+### ![Alternative text](https://tachiyomi.org/icons/logo.svg) [TachiyomiAZ](/forks/TachiyomiAZ), ![Alternative text](https://tachiyomi.org/icons/logo.svg)  [TachiyomiSY](/forks/TachiyomiSY) and ![Alternative text](https://tachiyomi.org/icons/logo.svg)  [TachiyomiEH](/forks/TachiyomiEH)
 
-These forks have some built-in extensions, namely: **E-Hentai**, **Hitomi.la**, and **nHentai** for <Navigation item="tachiyomiaz" /> and <Navigation item="tachiyomieh" /> while <Navigation item="tachiyomisy" /> only has **E-Hentai**.
+These forks have some built-in extensions, namely: **E-Hentai**, **Hitomi.la**, and **nHentai** for `<Navigation item="tachiyomiaz" /> and <Navigation item="tachiyomieh" /> while <Navigation item="tachiyomisy" />` only has **E-Hentai**.
 
 
 Titles from said extensions will not be restored when restoring a backup made by these forks to standard Tachiyomi. It is possible to restore titles to these forks, but it is not possible to back them up out of these forks.

--- a/content/help/guides/creating-backups.md
+++ b/content/help/guides/creating-backups.md
@@ -1,0 +1,59 @@
+---
+title: Creating backups
+description: Backups can save you a lot of headache in case something happens to your installation or device.
+lang: en-US
+---
+
+# Creating backups
+
+Backups are inter-compatible between **Tachiyomi** versions, with a few exceptions listed under [forks information](#forks-information).
+
+Backups can hold the following information:
+1. **Titles**
+1. **Categories**
+1. **Read chapters**
+1. **Tracking settings**
+1. **Reading history**
+
+::: guide
+You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/> and then selecting **Create backup** and select a location to save it.
+:::
+
+## Restoring
+
+Restoring is done from the <Navigation item="settings_backup"/> settings. To restore without issues be sure to:
+
+* Install all the <Navigation item="tab_extensions"/> that were installed at the time of the backup.
+* Log into the <Navigation item="settings_tracking"/> services that you use.
+* Log into **MangaDex** using **WebView** [as explained here](/help/faq/#no-results-when-searching).
+* You're able to access all the sources through the **WebView**.
+* Be on a consistent internet connection.
+
+## Transferring downloads
+
+You can transfer downloaded manga chapters from one version of **Tachiyomi** to another.
+
+::: guide
+You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_downloads"/> and then set the download directory to that of the download folder of your old **Tachiyomi**, then restore the backup.
+:::
+
+## Turning on auto-backups
+
+It is highly recommended you turn on auto backups, this will ensure you can recover if need be.
+
+::: guide
+You can do this by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_backup"/> and then setting a **backup frequency**. In the case of a catastrophic failure, at least you will be able to recover.
+:::
+
+## Forks information
+
+### <img class="forkIconBefore" src="/assets/forks_logo-neko.png" width="24" height="24" /> [Neko](/forks/Neko)
+
+This fork can only restore **MangaDex** entries in a backup. If there are entries from other sources that are a part of that backup then they will not transfer.
+
+### <img class="forkIconBefore" src="/assets/forks_logo-az.png" width="24" height="24" /> [TachiyomiAZ](/forks/TachiyomiAZ), <img class="forkIconBefore" src="/assets/forks_logo-sy.png" width="24" height="24" />  [TachiyomiSY](/forks/TachiyomiSY) and <img class="forkIconBefore" src="/assets/forks_logo-eh.png" width="24" height="24" />  [TachiyomiEH](/forks/TachiyomiEH)
+
+These forks have some built-in extensions, namely: **E-Hentai**, **Hitomi.la**, and **nHentai** for <Navigation item="tachiyomiaz" /> and <Navigation item="tachiyomieh" /> while <Navigation item="tachiyomisy" /> only has **E-Hentai**.
+
+
+Titles from said extensions will not be restored when restoring a backup made by these forks to standard Tachiyomi. It is possible to restore titles to these forks, but it is not possible to back them up out of these forks.

--- a/content/help/guides/getting-started.md
+++ b/content/help/guides/getting-started.md
@@ -1,0 +1,54 @@
+---
+title: Getting started
+description: Essential information to help you get set up with Tachiyomi.
+lang: en-US
+---
+
+# Getting started
+
+## Installation
+
+You can download the latest version of **Tachiyomi** by going to our [download](../../download/) page.
+When you've completed the download, open the <VersionTag fileName/> file and proceed with installing it.
+
+## Installing an extension
+
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_extension-install.mp4)
+:::
+
+Now that **Tachiyomi** is installed, open the app and navigate to <Navigation item="browse"/> and then switch to the **Extensions** tab.
+
+Find the extension that you'd like to use then press the <Navigation item="install"/> button next to your desired extension and then accept the installation prompt.
+
+::: c-warning
+You *might* need to give **Tachiyomi** the permission to *install unknown apps*, you can read how to do so [here](/help/faq/#how-do-i-allow-third-party-installations).
+:::
+
+## Adding manga to your library
+
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_library-add.mp4)
+:::
+
+Now that you've installed the desired extension, it will show in the **Sources** tab. This page contains all of your sources, which is obtained through extensions, some extensions contain *multiple* sources.
+
+To find and add manga to your library, tap **Latest** for a source's most recently updated manga, or tap on the source itself to browse and search their catalog.
+
+Now that you've presumably found manga that you want to add, click on it and then press the <Navigation item="bookmark"/> button, it should now appear in your <Navigation item="library"/> ready to be read!
+
+::: guide Other ways to search for manga
+You can also search for manga globally across all your sources by using <Navigation item="search"/> located in the top-right of <Navigation item="browse"/> → **Sources**.
+:::
+:::: guide Trouble finding a specific manga
+Check your spelling and try again, there's also the chance that your used source may not host the manga you're looking for.
+* Some sources use **Japanese romanized** titles instead of **English** ones.
+  > For example **Boku no Hero Academia** instead of **My Hero Academia**.
+* Some sources use different spellings.
+  > For example **Bungo Stray Dogs** instead of **Bungou Stray Dogs**.
+* Some sources use different wordings
+  > For example **3-gatsu no Lion** instead of **Sangatsu no Lion**.
+::: note
+Find more potential answers to your questions [here](/help/faq/#why-can-t-i-find-x-manga).
+:::
+::::

--- a/content/help/guides/getting-started.md
+++ b/content/help/guides/getting-started.md
@@ -9,17 +9,17 @@ lang: en-US
 ## Installation
 
 You can download the latest version of **Tachiyomi** by going to our [download](../../download/) page.
-When you've completed the download, open the <VersionTag fileName/> file and proceed with installing it.
+When you've completed the download, open the `<VersionTag fileName/>` file and proceed with installing it.
 
 ## Installing an extension
 
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_extension-install.mp4)
+`<MaterialIcon icon="videocam"/>` [ Click for video guide](/assets/guides_extension-install.mp4)
 :::
 
-Now that **Tachiyomi** is installed, open the app and navigate to <Navigation item="browse"/> and then switch to the **Extensions** tab.
+Now that **Tachiyomi** is installed, open the app and navigate to `<Navigation item="browse"/>` and then switch to the **Extensions** tab.
 
-Find the extension that you'd like to use then press the <Navigation item="install"/> button next to your desired extension and then accept the installation prompt.
+Find the extension that you'd like to use then press the `<Navigation item="install"/>` button next to your desired extension and then accept the installation prompt.
 
 ::: c-warning
 You *might* need to give **Tachiyomi** the permission to *install unknown apps*, you can read how to do so [here](/help/faq/#how-do-i-allow-third-party-installations).
@@ -28,17 +28,17 @@ You *might* need to give **Tachiyomi** the permission to *install unknown apps*,
 ## Adding manga to your library
 
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_library-add.mp4)
+`<MaterialIcon icon="videocam"/>` [ Click for video guide](/assets/guides_library-add.mp4)
 :::
 
 Now that you've installed the desired extension, it will show in the **Sources** tab. This page contains all of your sources, which is obtained through extensions, some extensions contain *multiple* sources.
 
 To find and add manga to your library, tap **Latest** for a source's most recently updated manga, or tap on the source itself to browse and search their catalog.
 
-Now that you've presumably found manga that you want to add, click on it and then press the <Navigation item="bookmark"/> button, it should now appear in your <Navigation item="library"/> ready to be read!
+Now that you've presumably found manga that you want to add, click on it and then press the `<Navigation item="bookmark"/>` button, it should now appear in your `<Navigation item="library"/>` ready to be read!
 
 ::: guide Other ways to search for manga
-You can also search for manga globally across all your sources by using <Navigation item="search"/> located in the top-right of <Navigation item="browse"/> → **Sources**.
+You can also search for manga globally across all your sources by using `<Navigation item="search"/>` located in the top-right of `<Navigation item="browse"/>` → **Sources**.
 :::
 :::: guide Trouble finding a specific manga
 Check your spelling and try again, there's also the chance that your used source may not host the manga you're looking for.

--- a/content/help/guides/reader-settings.md
+++ b/content/help/guides/reader-settings.md
@@ -4,10 +4,12 @@ description: Reader settings for Tachiyomi.
 lang: en-US
 ---
 
+import {Carousel,Slide} from 'vue-carousel'
+
 # Reader settings
 This section relates to the reading experience in the app and navigating the reader.
 
-## Default reading mode <Badge text="Right to left" type="default-indicator" vertical="middle" />
+## Default reading mode `<Badge text="Right to left" type="default-indicator" vertical="middle" />`
 This setting sets the reader's default direction when you open a manga.
 
 **Left to right**
@@ -29,23 +31,23 @@ This setting sets the reader's default direction when you open a manga.
 You can change viewer for different series by going to the series, opening a chapter, tapping the middle of the screen, pressing the gear icon, and selecting a different viewer in **Viewer for this series**.
 :::
 
-## Double tap animation speed <Badge text="Normal" type="default-indicator" vertical="middle" />
+## Double tap animation speed `<Badge text="Normal" type="default-indicator" vertical="middle" />`
 Double tap animation speed changes the speed in which the zoom happens when double tapping.
 
-## Show reading mode <Badge text="True" type="default-indicator" vertical="middle" />
+## Show reading mode `<Badge text="True" type="default-indicator" vertical="middle" />`
 Briefly show current mode when reader is opened
 
-## 32-bit color <Badge text="False" type="default-indicator" vertical="middle" />
+## 32-bit color `<Badge text="False" type="default-indicator" vertical="middle" />`
 This setting decodes images in `ARGB888` format to allow the reader to display more colors.
 
 ::: c-warning
 This setting will only show up on smartphones running **Android 8.0** or higher.
 :::
 
-## Animate page transitions <Badge text="True" type="default-indicator" vertical="middle" />
+## Animate page transitions `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting applies a smooth transition when tapping to change page.
 
-## Rotation <Badge text="Free" type="default-indicator" vertical="middle" />
+## Rotation `<Badge text="Free" type="default-indicator" vertical="middle" />`
 This allows you to control how the screen is going to be oriented.
 
 - **Free** lets you rotate the screen between portrait and landscape.
@@ -53,56 +55,56 @@ This allows you to control how the screen is going to be oriented.
 - **Force Portrait** forces the reader to be in portrait.
 - **Force Landscape** forces the reader to be in landscape.
 
-## Background color <Badge text="Black" type="default-indicator" vertical="middle" />
+## Background color `<Badge text="Black" type="default-indicator" vertical="middle" />`
 This allows you to control what color the background should be in reader. Background color can either be **Black**, **Gray** or
 **White**.
 
 <Carousel name="carousel-background-color">
-<CarouselItem>
-<figure class="centered">
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-black.png')">
-	<h4>Black</h4>
-	<p>Surrounds page with black. With an AMOLED screen you can save battery by using this.</p>
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-gray.png')">
-	<h4>Gray</h4>
-	<p>Surrounds page with gray.</p>
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-white.png')">
-	<h4>White</h4>
-	<p>Surrounds page with white. Makes pages seemless with the screen.</p>
-</figure>
-</CarouselItem>
+    <Slide>
+        <figure class="centered">
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+	        <h4>Black</h4>
+	        <p>Surrounds page with black. With an AMOLED screen you can save battery by using this.</p>
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+	        <h4>Gray</h4>
+	        <p>Surrounds page with gray.</p>
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+	        <h4>White</h4>
+	        <p>Surrounds page with white. Makes pages seemless with the screen.</p>
+        </figure>
+    </Slide>
 </Carousel>
 
-## Fullscreen <Badge text="True" type="default-indicator" vertical="middle" />
+## Fullscreen `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting specifies if the notification and navigation bar are to be hidden while in the reader.
 
-## Show content in cutout area <Badge text="True" type="default-indicator" vertical="middle" />
+## Show content in cutout area `<Badge text="True" type="default-indicator" vertical="middle" />`
 Lets reader use all screen space even that around punch hole camera and camera notch 
 
-## Keep screen on <Badge text="True" type="default-indicator" vertical="middle" />
+## Keep screen on `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting determines if the device should be allowed to go to sleep while reading a manga.
 
-## Show page number <Badge text="True" type="default-indicator" vertical="middle" />
+## Show page number `<Badge text="True" type="default-indicator" vertical="middle" />`
 This settings shows the page number at the bottom of the page in current page/total page format.
 
-## Skip chapters marked read <Badge text="False" type="default-indicator" vertical="middle" />
+## Skip chapters marked read `<Badge text="False" type="default-indicator" vertical="middle" />`
 This setting allows the chapters marked as read to be skipped during reading. This setting can be useful if a series has multiple scanlation groups and you want to hide one's chapters during reading.
 
-## Skip filtered chapters <Badge text="True" type="default-indicator" vertical="middle" />
+## Skip filtered chapters `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting allows filtered chapters to be skipped during reading.
 
-## Always show chapter transition <Badge text="True" type="default-indicator" vertical="middle" />
+## Always show chapter transition `<Badge text="True" type="default-indicator" vertical="middle" />`
 Chapter transition is the area between chapters that shows the names of current and next chapters. When this option is disabled, the reader will hide this area only if the next chapter is loaded.
 
-## Scale type <Badge text="Fit screen" type="default-indicator" vertical="middle" />
+## Scale type `<Badge text="Fit screen" type="default-indicator" vertical="middle" />`
 Scale type lets you choose how the page fits in your screen.
 
 ### Examples
@@ -110,52 +112,52 @@ Scale type lets you choose how the page fits in your screen.
 All examples are illustrations and may not reflect what actually happens.
 
 <Carousel name="carousel-scale-type">
-<CarouselItem>
-<figure class="centered">
-	<h4>Fit screen</h4>
-	<p>Will fit either to width or height depending on image resolution</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-screen.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Stretch</h4>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-stretch.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Fit width</h4>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-width.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Fit height</h4>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-height.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Original size</h4>
-	<p>Will be either zoom in or out depending on image resolution</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-original-size.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Smart fit</h4>
-	<p>Fits to the longest side of the image</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-smart-fit.png')">
-</figure>
-</CarouselItem>
+    <Slide>
+        <figure class="centered">
+	        <h4>Fit screen</h4>
+	        <p>Will fit either to width or height depending on image resolution</p>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Stretch</h4>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Fit width</h4>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Fit height</h4>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Original size</h4>
+	        <p>Will be either zoom in or out depending on image resolution</p>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Smart fit</h4>
+	        <p>Fits to the longest side of the image</p>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
 </Carousel>
 
 ::: c-tip
 You can change scale type when reading a chapter. Tap the middle of the screen, press the gear icon at the top, select a different scale type under **Scale type**. This will change Scale type for all series.
 :::
 
-## Zoom start position <Badge text="Automatic" type="default-indicator" vertical="middle" />
+## Zoom start position `<Badge text="Automatic" type="default-indicator" vertical="middle" />`
 Depending on your scale type the page can be wider than the screen, and with zoom start position you can choose where
 Tachiyomi will start on that zoomed in page.
 
@@ -164,54 +166,54 @@ Tachiyomi will start on that zoomed in page.
 All examples are illustrations
 
 <Carousel name="carousel-zoom-start-position">
-<CarouselItem>
-<figure class="centered">
-	<h4>Left</h4>
-	<p>Will start at the left side of the page.</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-left.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Right</h4>
-	<p>Will start at the right side of the page.</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-right.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>Center</h4>
-	<p>Will start at the center of the page.</p>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-center.png')">
-</figure>
-</CarouselItem>
+    <Slide>
+        <figure class="centered">
+	        <h4>Left</h4>
+	        <p>Will start at the left side of the page.</p>
+	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Right</h4>
+	        <p>Will start at the right side of the page.</p>
+            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>Center</h4>
+	        <p>Will start at the center of the page.</p>
+            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
 </Carousel>
 
-## Crop borders <Badge text="False" type="default-indicator" vertical="middle" />
+## Crop borders `<Badge text="False" type="default-indicator" vertical="middle" />`
 Tries to remove excess white borders
 
 <Carousel name="carousel-crop-borders">
-<CarouselItem>
-<figure class="centered">
-	<h4>With Crop borders on</h4>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-crop-border-on.png')">
-</figure>
-</CarouselItem>
-<CarouselItem>
-<figure class="centered">
-	<h4>With Crop borders off</h4>
-	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-crop-border-off.png')">
-</figure>
-</CarouselItem>
+    <Slide>
+        <figure class="centered">
+	        <h4>With Crop borders on</h4>
+            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
+    <Slide>
+        <figure class="centered">
+	        <h4>With Crop borders off</h4>
+            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
+        </figure>
+    </Slide>
 </Carousel>
 
-## Side padding <Badge text="Webtoon" type="tip" vertical="middle" /> <Badge text="None" type="default-indicator" vertical="middle" />
+## Side padding `<Badge text="Webtoon" type="tip" vertical="middle" /> <Badge text="None" type="default-indicator" vertical="middle" />`
 Adds a percentage side padding to the sides of the page
 
-## Tapping <Badge text="True" type="default-indicator" vertical="middle" />
+## Tapping `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting enables switching pages by tapping the sides of the screen.
 
-## Invert Tapping <Badge text="None" type="default-indicator" vertical="middle" />
+## Invert Tapping `<Badge text="None" type="default-indicator" vertical="middle" />`
 Inverts the tapping position depending on which setting you choose.
 
 **None**
@@ -231,13 +233,13 @@ Inverts the tapping position depending on which setting you choose.
 This setting can only be used when Tapping is enabled.
 :::
 
-## Long tap dialog <Badge text="True" type="default-indicator" vertical="middle" />
+## Long tap dialog `<Badge text="True" type="default-indicator" vertical="middle" />`
 If enabled, you can long tap on the screen to get the options to set the current page as cover, share it, or save it.
 
-## Volume keys <Badge text="False" type="default-indicator" vertical="middle" />
+## Volume keys `<Badge text="False" type="default-indicator" vertical="middle" />`
 This setting allows you to flip pages using the volume keys, with the volume up button going to the previous page, and volume down going to next page.
 
-## Invert volume keys <Badge text="False" type="default-indicator" vertical="middle" />
+## Invert volume keys `<Badge text="False" type="default-indicator" vertical="middle" />`
 
 Reverses the Volume keys function of volume up going to the next page and volume down going to the last page.
 

--- a/content/help/guides/reader-settings.md
+++ b/content/help/guides/reader-settings.md
@@ -1,0 +1,246 @@
+---
+title: Reader settings
+description: Reader settings for Tachiyomi.
+lang: en-US
+---
+
+# Reader settings
+This section relates to the reading experience in the app and navigating the reader.
+
+## Default reading mode <Badge text="Right to left" type="default-indicator" vertical="middle" />
+This setting sets the reader's default direction when you open a manga.
+
+**Left to right**
+- Swipe left for next page. Swipe right for previous page.
+
+**Right to left**
+- Swipe right for next page. Swipe left for previous page. Default way of reading Manga.
+
+**Vertical**
+- Swipe up for next page. Swipe down for previous.
+
+**Webtoon**
+- Webtoon is like vertical but stitches all the images together into one stream.
+
+**Continuous vertical**
+- Similar to webtoon but with a little space between pages.
+
+::: c-tip
+You can change viewer for different series by going to the series, opening a chapter, tapping the middle of the screen, pressing the gear icon, and selecting a different viewer in **Viewer for this series**.
+:::
+
+## Double tap animation speed <Badge text="Normal" type="default-indicator" vertical="middle" />
+Double tap animation speed changes the speed in which the zoom happens when double tapping.
+
+## Show reading mode <Badge text="True" type="default-indicator" vertical="middle" />
+Briefly show current mode when reader is opened
+
+## 32-bit color <Badge text="False" type="default-indicator" vertical="middle" />
+This setting decodes images in `ARGB888` format to allow the reader to display more colors.
+
+::: c-warning
+This setting will only show up on smartphones running **Android 8.0** or higher.
+:::
+
+## Animate page transitions <Badge text="True" type="default-indicator" vertical="middle" />
+This setting applies a smooth transition when tapping to change page.
+
+## Rotation <Badge text="Free" type="default-indicator" vertical="middle" />
+This allows you to control how the screen is going to be oriented.
+
+- **Free** lets you rotate the screen between portrait and landscape.
+- **Lock** will lock the orientation to whatever orientation you had before entering the reader.
+- **Force Portrait** forces the reader to be in portrait.
+- **Force Landscape** forces the reader to be in landscape.
+
+## Background color <Badge text="Black" type="default-indicator" vertical="middle" />
+This allows you to control what color the background should be in reader. Background color can either be **Black**, **Gray** or
+**White**.
+
+<Carousel name="carousel-background-color">
+<CarouselItem>
+<figure class="centered">
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-black.png')">
+	<h4>Black</h4>
+	<p>Surrounds page with black. With an AMOLED screen you can save battery by using this.</p>
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-gray.png')">
+	<h4>Gray</h4>
+	<p>Surrounds page with gray.</p>
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-background-white.png')">
+	<h4>White</h4>
+	<p>Surrounds page with white. Makes pages seemless with the screen.</p>
+</figure>
+</CarouselItem>
+</Carousel>
+
+## Fullscreen <Badge text="True" type="default-indicator" vertical="middle" />
+This setting specifies if the notification and navigation bar are to be hidden while in the reader.
+
+## Show content in cutout area <Badge text="True" type="default-indicator" vertical="middle" />
+Lets reader use all screen space even that around punch hole camera and camera notch 
+
+## Keep screen on <Badge text="True" type="default-indicator" vertical="middle" />
+This setting determines if the device should be allowed to go to sleep while reading a manga.
+
+## Show page number <Badge text="True" type="default-indicator" vertical="middle" />
+This settings shows the page number at the bottom of the page in current page/total page format.
+
+## Skip chapters marked read <Badge text="False" type="default-indicator" vertical="middle" />
+This setting allows the chapters marked as read to be skipped during reading. This setting can be useful if a series has multiple scanlation groups and you want to hide one's chapters during reading.
+
+## Skip filtered chapters <Badge text="True" type="default-indicator" vertical="middle" />
+This setting allows filtered chapters to be skipped during reading.
+
+## Always show chapter transition <Badge text="True" type="default-indicator" vertical="middle" />
+Chapter transition is the area between chapters that shows the names of current and next chapters. When this option is disabled, the reader will hide this area only if the next chapter is loaded.
+
+## Scale type <Badge text="Fit screen" type="default-indicator" vertical="middle" />
+Scale type lets you choose how the page fits in your screen.
+
+### Examples
+
+All examples are illustrations and may not reflect what actually happens.
+
+<Carousel name="carousel-scale-type">
+<CarouselItem>
+<figure class="centered">
+	<h4>Fit screen</h4>
+	<p>Will fit either to width or height depending on image resolution</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-screen.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Stretch</h4>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-stretch.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Fit width</h4>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-width.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Fit height</h4>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-fit-height.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Original size</h4>
+	<p>Will be either zoom in or out depending on image resolution</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-original-size.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Smart fit</h4>
+	<p>Fits to the longest side of the image</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-smart-fit.png')">
+</figure>
+</CarouselItem>
+</Carousel>
+
+::: c-tip
+You can change scale type when reading a chapter. Tap the middle of the screen, press the gear icon at the top, select a different scale type under **Scale type**. This will change Scale type for all series.
+:::
+
+## Zoom start position <Badge text="Automatic" type="default-indicator" vertical="middle" />
+Depending on your scale type the page can be wider than the screen, and with zoom start position you can choose where
+Tachiyomi will start on that zoomed in page.
+
+### Examples
+
+All examples are illustrations
+
+<Carousel name="carousel-zoom-start-position">
+<CarouselItem>
+<figure class="centered">
+	<h4>Left</h4>
+	<p>Will start at the left side of the page.</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-left.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Right</h4>
+	<p>Will start at the right side of the page.</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-right.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>Center</h4>
+	<p>Will start at the center of the page.</p>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-zoomstartpos-center.png')">
+</figure>
+</CarouselItem>
+</Carousel>
+
+## Crop borders <Badge text="False" type="default-indicator" vertical="middle" />
+Tries to remove excess white borders
+
+<Carousel name="carousel-crop-borders">
+<CarouselItem>
+<figure class="centered">
+	<h4>With Crop borders on</h4>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-crop-border-on.png')">
+</figure>
+</CarouselItem>
+<CarouselItem>
+<figure class="centered">
+	<h4>With Crop borders off</h4>
+	<img height="400" intrinsicsize="208x500" width="260" :src="$withBase('/assets/guides_reader-crop-border-off.png')">
+</figure>
+</CarouselItem>
+</Carousel>
+
+## Side padding <Badge text="Webtoon" type="tip" vertical="middle" /> <Badge text="None" type="default-indicator" vertical="middle" />
+Adds a percentage side padding to the sides of the page
+
+## Tapping <Badge text="True" type="default-indicator" vertical="middle" />
+This setting enables switching pages by tapping the sides of the screen.
+
+## Invert Tapping <Badge text="None" type="default-indicator" vertical="middle" />
+Inverts the tapping position depending on which setting you choose.
+
+**None**
+- Tapping left goes to the next page, and tapping right goes to the previous page
+- Tapping bottom goes to the next page, and tapping top goes to the previous page
+
+**Horizontal**
+- Tapping left goes to the previous page, and tapping right goes to the next page
+
+**Vertical**
+- Tapping bottom goes to the previous page, and tapping top goes to the next page
+
+**Both**
+- Applies the two previous mentioned settings
+
+::: c-warning
+This setting can only be used when Tapping is enabled.
+:::
+
+## Long tap dialog <Badge text="True" type="default-indicator" vertical="middle" />
+If enabled, you can long tap on the screen to get the options to set the current page as cover, share it, or save it.
+
+## Volume keys <Badge text="False" type="default-indicator" vertical="middle" />
+This setting allows you to flip pages using the volume keys, with the volume up button going to the previous page, and volume down going to next page.
+
+## Invert volume keys <Badge text="False" type="default-indicator" vertical="middle" />
+
+Reverses the Volume keys function of volume up going to the next page and volume down going to the last page.
+
+::: c-warning
+This setting can only be used when Volume keys setting is enabled.
+:::

--- a/content/help/guides/reader-settings.md
+++ b/content/help/guides/reader-settings.md
@@ -4,7 +4,7 @@ description: Reader settings for Tachiyomi.
 lang: en-US
 ---
 
-import {Carousel,Slide} from 'vue-carousel'
+import Carousel from '~/components/carousel/Carousel.vue'
 
 # Reader settings
 This section relates to the reading experience in the app and navigating the reader.
@@ -58,30 +58,23 @@ This allows you to control how the screen is going to be oriented.
 ## Background color `<Badge text="Black" type="default-indicator" vertical="middle" />`
 This allows you to control what color the background should be in reader. Background color can either be **Black**, **Gray** or
 **White**.
-
-<Carousel name="carousel-background-color">
-    <Slide>
-        <figure class="centered">
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-	        <h4>Black</h4>
-	        <p>Surrounds page with black. With an AMOLED screen you can save battery by using this.</p>
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-	        <h4>Gray</h4>
-	        <p>Surrounds page with gray.</p>
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-	        <h4>White</h4>
-	        <p>Surrounds page with white. Makes pages seemless with the screen.</p>
-        </figure>
-    </Slide>
-</Carousel>
+<Carousel v-bind:items="[
+    {
+        title: 'Black', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Surrounds page with black. With an AMOLED screen you can save battery by using this.'
+    },
+    {
+        title: 'Gray', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Surrounds page with gray.'
+    },
+    {
+        title: 'White', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Surrounds page with white. Makes pages seemless with the screen.'
+    }
+]" />
 
 ## Fullscreen `<Badge text="True" type="default-indicator" vertical="middle" />`
 This setting specifies if the notification and navigation bar are to be hidden while in the reader.
@@ -111,47 +104,34 @@ Scale type lets you choose how the page fits in your screen.
 
 All examples are illustrations and may not reflect what actually happens.
 
-<Carousel name="carousel-scale-type">
-    <Slide>
-        <figure class="centered">
-	        <h4>Fit screen</h4>
-	        <p>Will fit either to width or height depending on image resolution</p>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Stretch</h4>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Fit width</h4>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Fit height</h4>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Original size</h4>
-	        <p>Will be either zoom in or out depending on image resolution</p>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Smart fit</h4>
-	        <p>Fits to the longest side of the image</p>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-</Carousel>
+<Carousel v-bind:items="[
+    {
+        title: 'Fit screen', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+    },
+    {
+        title: 'Stretch', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+    },
+    {
+        title: 'Fit width', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+    },
+    {
+        title: 'Fit height', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+    },
+    {
+        title: 'Original size', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Will be either zoom in or out depending on image resolution'
+    },
+    {
+        title: 'Smart fit', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Fits to the longest side of the image'
+    }
+]" />
 
 ::: c-tip
 You can change scale type when reading a chapter. Tap the middle of the screen, press the gear icon at the top, select a different scale type under **Scale type**. This will change Scale type for all series.
@@ -165,29 +145,23 @@ Tachiyomi will start on that zoomed in page.
 
 All examples are illustrations
 
-<Carousel name="carousel-zoom-start-position">
-    <Slide>
-        <figure class="centered">
-	        <h4>Left</h4>
-	        <p>Will start at the left side of the page.</p>
-	        <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Right</h4>
-	        <p>Will start at the right side of the page.</p>
-            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-    <Slide>
-        <figure class="centered">
-	        <h4>Center</h4>
-	        <p>Will start at the center of the page.</p>
-            <img height="400" intrinsicsize="208x500" width="260" src="https://tachiyomi.org/icons/logo.svg">
-        </figure>
-    </Slide>
-</Carousel>
+<Carousel v-bind:items="[
+    {
+        title: 'Left', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Will start at the left side of the page.'
+    },
+    {
+        title: 'Right', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Will start at the right side of the page.'
+    },
+    {
+        title: 'Center', 
+        image: 'https://tachiyomi.org/icons/logo.svg', 
+        desc: 'Will start at the center of the page.'
+    }
+]" />
 
 ## Crop borders `<Badge text="False" type="default-indicator" vertical="middle" />`
 Tries to remove excess white borders

--- a/content/help/guides/reading-local-manga.md
+++ b/content/help/guides/reading-local-manga.md
@@ -1,0 +1,163 @@
+---
+title: Reading local manga
+description: All the information you would need to read your own local manga.
+lang: en-US
+---
+
+# Reading local manga
+
+Follow the steps below to create local manga.
+
+1. Create a folder named `local` in the `/Tachiyomi/` folder.
+	> This is located in the phone's **internal storage** or **external SD card**.
+1. Place correctly structured manga inside `/Tachiyomi/local/`.
+	<ul>
+  		<li>Optional: If adding manga in folders, add a file named `.nomedia` to the local folder so images do not show up in the gallery</li>
+	</ul> 
+1. You can then access the manga in <Navigation item="browse"/> → **Local source**.
+
+If you add more chapters then you'll have to manually refresh the chapter list (by pulling down the list).
+
+Supported chapter formats are folder with pictures inside (such as `.jpg`, `.png`, etc), `ZIP`/`CBZ`, `RAR`/`CBR` and `EPUB`. But expect better performance with directories and `ZIP`/`CBZ`.
+
+::: c-warning
+Remember to give the app storage permissions on **Android 6** and newer.
+:::
+
+## Folder Structure
+
+Tachiyomi requires a specific folder structure for local manga to be correctly processed. Local manga will be read from the `Tachiyomi/local` folder. Each manga must have a `Manga` folder and a `Chapter` folder. Images will then go into the chapter folder. See below for more information on archive files. You can refer to the following example:
+
+::: guide Example (Folder)
+<div class="side-by-side">
+	<ul class="file-tree">
+		<li>
+			/sdcard/Tachiyomi/local
+			<ul>
+				<li>
+					<span class="ft-icon ft-folder">Manga title</span>
+					<ul>
+						<li>
+							<span class="ft-icon ft-folder">ch1</span>
+							<ul>
+								<span class="ft-icon ft-image">images</span>
+							</ul>
+						</li>
+						<li>
+							<span class="ft-icon ft-folder">ch2</span>
+							<ul>
+								<span class="ft-icon ft-image">images</span>
+							</ul>
+						</li>
+						<span class="ft-icon ft-image">cover.jpg</span>
+					</ul>
+				</li>
+				<li>...</li>
+			</ul>
+		</li>
+	</ul>
+	<ul class="file-tree">
+		<li>
+			/storage/18F5-2C11/Tachiyomi/local
+			<ul>
+				<li>
+					<span class="ft-icon ft-folder">Manga title</span>
+					<ul>
+						<li>
+							<span class="ft-icon ft-folder">ch3</span>
+							<ul>
+								<span class="ft-icon ft-image">images</span>
+							</ul>
+						</li>
+						<li>
+							<span class="ft-icon ft-folder">ch4</span>
+							<ul>
+								<span class="ft-icon ft-image">images</span>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li>...</li>
+			</ul>
+		</li>
+	</ul>
+</div>
+:::
+
+Tachiyomi will see four chapters in a single manga.
+The path to the folder with images must contain both the manga title and the chapter name (as seen above).
+
+::: guide-empty
+<figure class="centered">
+	<h4>Example structure using the file manager</h4>
+	<p>Here, the manga name is <strong>test</strong> so the file structure is <code>/Tachiyomi/local/test/ch1/images</code>.</p>
+	<img class="zoomable" height="300" :src="$withBase('/assets/guides_local-manga.jpg')">
+</figure>
+:::
+
+## Archive Files
+Archive files such as `ZIP`/`CBZ` are supported but the folder structure inside is not. Any folders inside the archive file are ignored. You must place the archive inside the `Manga` folder where the name will become the `Chapter` title. All images inside the archive regardless of folder structure will become pages for that chapter.
+
+::: guide Example (ZIP)
+<ul class="file-tree">
+		<li>
+			/sdcard/Tachiyomi/local
+			<ul>
+				<li>
+					<span class="ft-icon ft-folder">Manga title</span>
+					<ul>
+						<li>
+							<span class="ft-icon ft-zip">ch1.zip</span>
+							<ul>
+								<span class="ft-icon ft-image">images</span>
+							</ul>
+						</li>
+						<li>
+							<span class="ft-icon ft-zip">ch2.zip</span>
+							<ul>
+								<li>
+									<span class="ft-icon ft-folder">ch2</span>
+									<ul>
+										<span class="ft-icon ft-image">images</span>
+									</ul>
+								</li>
+							</ul>
+						</li>
+						<span class="ft-icon ft-image">cover.jpg</span>
+					</ul>
+				</li>
+				<li>...</li>
+			</ul>
+		</li>
+</ul>
+:::
+
+
+## Advanced
+
+### Editing local manga details
+
+It is possible to add details to local manga. Like manga from other catalogs, you add information about the manga such as the author, artist, description, and genre tags.
+
+To import details along with your local manga, you have to create a json file. It can be named anything but it must be placed within the **Manga** folder. A standard file name is `details.json`. This file will contain the extended details about the manga in the `JSON` format. You can see the example below on how to build the file. Once the file is there, the app should load the data when you first open the manga or you can pull down to refresh the details.
+
+You can copy the following example and edit the details as needed:
+``` json
+{
+	"title": "Example Title",
+	"author": "Example Author",
+	"artist": "Example Artist",
+	"description": "Example Description",
+	"genre": ["genre 1", "genre 2", "etc"],
+	"status": "0",
+	"_status values": ["0 = Unknown", "1 = Ongoing", "2 = Completed", "3 = Licensed"]
+}
+```
+
+### Using a custom cover image
+
+It is also possible to use a custom image as a cover for each local manga.
+
+To do this, you only need to place the image file, that needs to be named
+`cover.jpg`, in the root of the manga folder. The app will then use your
+custom image in the local source listing.

--- a/content/help/guides/reading-local-manga.md
+++ b/content/help/guides/reading-local-manga.md
@@ -14,7 +14,7 @@ Follow the steps below to create local manga.
 	<ul>
   		<li>Optional: If adding manga in folders, add a file named `.nomedia` to the local folder so images do not show up in the gallery</li>
 	</ul> 
-1. You can then access the manga in <Navigation item="browse"/> → **Local source**.
+1. You can then access the manga in `<Navigation item="browse"/>` → **Local source**.
 
 If you add more chapters then you'll have to manually refresh the chapter list (by pulling down the list).
 
@@ -91,7 +91,7 @@ The path to the folder with images must contain both the manga title and the cha
 <figure class="centered">
 	<h4>Example structure using the file manager</h4>
 	<p>Here, the manga name is <strong>test</strong> so the file structure is <code>/Tachiyomi/local/test/ch1/images</code>.</p>
-	<img class="zoomable" height="300" :src="$withBase('/assets/guides_local-manga.jpg')">
+	<img class="zoomable" height="300" src="https://tachiyomi.org/icons/logo.svg">
 </figure>
 :::
 

--- a/content/help/guides/source-migration.md
+++ b/content/help/guides/source-migration.md
@@ -1,0 +1,121 @@
+---
+title: Source migration
+description: Your source is no longer accessible or you just want to move to another? No problem.
+lang: en-US
+---
+
+# Source migration
+
+Migration is the process of moving manga between sources without losing progress. This is most often used when a source is no longer accessible or another source is more up-to-date.
+
+::: c-warning
+Always make sure to have a [backup](/help/guides/creating-backups/) in case anything unexpected occurs.
+:::
+
+## Migrating on Stable/Preview
+
+:::: guide Migrating from Manga
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-preview-manga.mp4)
+:::
+
+1. Tap into a **Manga** you would like to migrate.
+1. Go to <Navigation item="overflow"/> and tap <Navigation item="migrate" />.
+	> **Tachiyomi** will do a global search of all the sources you have installed and enabled.
+1. Select the **Source** that you'd like to migrate *to* by tapping the **Manga** thumbnail.
+1. Choose which data you want to transfer over, and you're done.
+::::
+
+:::: guide Migrating from Source
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-preview-source.mp4)
+:::
+
+1. Tap into <Navigation item="browse"/> on the bottom navbar.
+1. Press the <Navigation item="migrate" /> tab at the top next to <Navigation item="extensions" />.
+1. Select the **Source** that you'd like to migrate *from*.
+1. Tap the **Manga** you'd like to migrate *from* the **Source**.
+	> **Tachiyomi** will do a global search of all the sources you have installed and enabled.
+1. Select the **Source** you'd like to migrate *to* by tapping the **Manga** thumbnail.
+1. Choose which data you want to transfer over, and you're done.
+::::
+
+::: c-tip Searching only pinned sources
+You can restrict global searching to pinned sources if you wish to declutter your search.</br>To do this, go to <Navigation item="more"/> → <Navigation item="settings"/> →  <Navigation item="browse"/> then toggle the **Only include pinned sources** setting.
+
+Pin sources in <Navigation item="browse"/> using the <MaterialIcon icon="push_pin" /> pin icon next to the source name.
+:::
+
+## Migrating on TachiyomiJ2K
+
+:::: guide Migrating multiple manga
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-j2k.mp4)
+:::
+
+1. Tap <MaterialIcon icon="settings"/> **Settings** → <MaterialIcon icon="explore"/> **Sources** → **Source migration**.
+1. Select the **Source** you'd like to migrate *from* and select **All**.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow at the bottom right.
+1. Choose which data you want to transfer over.
+1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**.
+::::
+
+:::: guide Migrating a single manga
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-j2k-single.mp4)
+:::
+
+1. Tap into a **Manga** in your Library.
+1. Tap <Navigation item="overflow"/> → **Migrate manga**.
+1. Select the **Sources** you'd like to search and migrate *to* and hit the arrow at the bottom right.
+1. Wait until it is found and select <MaterialIcon icon="done"/> in the top right and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**
+::::
+
+## Migrating on TachiyomiAZ
+
+:::: guide Instructions
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-az.mp4)
+:::
+
+1. Tap into <Navigation item="library"/>.
+1. Tap <Navigation item="overflow"/>  → **Source migration**.
+1. Select the **Source** you'd like to migrate *from* and select **All**.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow at the bottom right.
+1. Choose which data you want to transfer over.
+1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**.
+::::
+
+## Migrating on TachiyomiSY
+
+:::: guide Migrating from Library
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-sy-library.mp4)
+:::
+
+1. Tap into <Navigation item="library"/>.
+1. Tap <Navigation item="overflow"/> → **Source migration**.
+1. Select the **Source** you'd like to migrate *from* and select **All**.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled <Navigation item="migrate" />. at the bottom right.
+1. Choose which data you want to transfer over.
+1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/>  → **Search manually**.
+::::
+
+:::: guide Migrating from Source
+::: videolink
+[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-sy-source.mp4)
+:::
+
+1. Tap into <Navigation item="browse"/> on the bottom navbar.
+1. Press the <Navigation item="migrate" /> tab at the top next to <Navigation item="extensions" />.
+1. Select the **Source** that you'd like to migrate *from*.
+1. Select the **Source** you'd like to migrate *from* and select **All**.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled <Navigation item="migrate" />. at the bottom right.
+1. Choose which data you want to transfer over.
+1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/>  → **Search manually**.
+::::

--- a/content/help/guides/source-migration.md
+++ b/content/help/guides/source-migration.md
@@ -16,11 +16,11 @@ Always make sure to have a [backup](/help/guides/creating-backups/) in case anyt
 
 :::: guide Migrating from Manga
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-preview-manga.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-preview-manga.mp4)
 :::
 
 1. Tap into a **Manga** you would like to migrate.
-1. Go to <Navigation item="overflow"/> and tap <Navigation item="migrate" />.
+1. Go to `<Navigation item="overflow"/>` and tap `<Navigation item="migrate" />`.
 	> **Tachiyomi** will do a global search of all the sources you have installed and enabled.
 1. Select the **Source** that you'd like to migrate *to* by tapping the **Manga** thumbnail.
 1. Choose which data you want to transfer over, and you're done.
@@ -28,11 +28,11 @@ Always make sure to have a [backup](/help/guides/creating-backups/) in case anyt
 
 :::: guide Migrating from Source
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-preview-source.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-preview-source.mp4)
 :::
 
-1. Tap into <Navigation item="browse"/> on the bottom navbar.
-1. Press the <Navigation item="migrate" /> tab at the top next to <Navigation item="extensions" />.
+1. Tap into `<Navigation item="browse"/>` on the bottom navbar.
+1. Press the `<Navigation item="migrate" />` tab at the top next to `<Navigation item="extensions" />`.
 1. Select the **Source** that you'd like to migrate *from*.
 1. Tap the **Manga** you'd like to migrate *from* the **Source**.
 	> **Tachiyomi** will do a global search of all the sources you have installed and enabled.
@@ -41,81 +41,81 @@ Always make sure to have a [backup](/help/guides/creating-backups/) in case anyt
 ::::
 
 ::: c-tip Searching only pinned sources
-You can restrict global searching to pinned sources if you wish to declutter your search.</br>To do this, go to <Navigation item="more"/> → <Navigation item="settings"/> →  <Navigation item="browse"/> then toggle the **Only include pinned sources** setting.
+You can restrict global searching to pinned sources if you wish to declutter your search.</br>To do this, go to `<Navigation item="more"/> → <Navigation item="settings"/> →  <Navigation item="browse"/>` then toggle the **Only include pinned sources** setting.
 
-Pin sources in <Navigation item="browse"/> using the <MaterialIcon icon="push_pin" /> pin icon next to the source name.
+Pin sources in `<Navigation item="browse"/>` using the `<MaterialIcon icon="push_pin" />` pin icon next to the source name.
 :::
 
 ## Migrating on TachiyomiJ2K
 
 :::: guide Migrating multiple manga
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-j2k.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-j2k.mp4)
 :::
 
-1. Tap <MaterialIcon icon="settings"/> **Settings** → <MaterialIcon icon="explore"/> **Sources** → **Source migration**.
+1. Tap `<MaterialIcon icon="settings"/>` **Settings** → `<MaterialIcon icon="explore"/>` **Sources** → **Source migration**.
 1. Select the **Source** you'd like to migrate *from* and select **All**.
 1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow at the bottom right.
 1. Choose which data you want to transfer over.
-1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
-	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**.
+1. Wait until all your **Manga** is found and hit the `<MaterialIcon icon="done_all"/>` at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing `<Navigation item="overflow"/>` → **Search manually**.
 ::::
 
 :::: guide Migrating a single manga
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-j2k-single.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-j2k-single.mp4)
 :::
 
 1. Tap into a **Manga** in your Library.
-1. Tap <Navigation item="overflow"/> → **Migrate manga**.
+1. Tap `<Navigation item="overflow"/>` → **Migrate manga**.
 1. Select the **Sources** you'd like to search and migrate *to* and hit the arrow at the bottom right.
-1. Wait until it is found and select <MaterialIcon icon="done"/> in the top right and you're done.
-	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**
+1. Wait until it is found and select `<MaterialIcon icon="done"/>` in the top right and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing `<Navigation item="overflow"/>` → **Search manually**
 ::::
 
 ## Migrating on TachiyomiAZ
 
 :::: guide Instructions
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-az.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-az.mp4)
 :::
 
-1. Tap into <Navigation item="library"/>.
-1. Tap <Navigation item="overflow"/>  → **Source migration**.
+1. Tap into `<Navigation item="library"/>`.
+1. Tap `<Navigation item="overflow"/>`  → **Source migration**.
 1. Select the **Source** you'd like to migrate *from* and select **All**.
 1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow at the bottom right.
 1. Choose which data you want to transfer over.
-1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
-	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/> → **Search manually**.
+1. Wait until all your **Manga** is found and hit the `<MaterialIcon icon="done_all"/>` at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing `<Navigation item="overflow"/>` → **Search manually**.
 ::::
 
 ## Migrating on TachiyomiSY
 
 :::: guide Migrating from Library
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-sy-library.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-sy-library.mp4)
 :::
 
-1. Tap into <Navigation item="library"/>.
-1. Tap <Navigation item="overflow"/> → **Source migration**.
+1. Tap into `<Navigation item="library"/>`.
+1. Tap `<Navigation item="overflow"/>` → **Source migration**.
 1. Select the **Source** you'd like to migrate *from* and select **All**.
-1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled <Navigation item="migrate" />. at the bottom right.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled `<Navigation item="migrate" />`. at the bottom right.
 1. Choose which data you want to transfer over.
-1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
-	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/>  → **Search manually**.
+1. Wait until all your **Manga** is found and hit the `<MaterialIcon icon="done_all"/>` at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing `<Navigation item="overflow"/>`  → **Search manually**.
 ::::
 
 :::: guide Migrating from Source
 ::: videolink
-[<MaterialIcon icon="videocam"/> Click for video guide](/assets/guides_migrate-sy-source.mp4)
+`<MaterialIcon icon="videocam"/>`[ Click for video guide](/assets/guides_migrate-sy-source.mp4)
 :::
 
-1. Tap into <Navigation item="browse"/> on the bottom navbar.
-1. Press the <Navigation item="migrate" /> tab at the top next to <Navigation item="extensions" />.
+1. Tap into `<Navigation item="browse"/>` on the bottom navbar.
+1. Press the `<Navigation item="migrate" />` tab at the top next to `<Navigation item="extensions" />`.
 1. Select the **Source** that you'd like to migrate *from*.
 1. Select the **Source** you'd like to migrate *from* and select **All**.
-1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled <Navigation item="migrate" />. at the bottom right.
+1. Select the **Sources** that you'd like to migrate *to* and search by and tap the arrow labeled `<Navigation item="migrate" />`. at the bottom right.
 1. Choose which data you want to transfer over.
-1. Wait until all your **Manga** is found and hit the <MaterialIcon icon="done_all"/> at the top and you're done.
-	> If a manga is not found, or is wrong you can manually search it by pressing <Navigation item="overflow"/>  → **Search manually**.
+1. Wait until all your **Manga** is found and hit the `<MaterialIcon icon="done_all"/>` at the top and you're done.
+	> If a manga is not found, or is wrong you can manually search it by pressing `<Navigation item="overflow"/>`  → **Search manually**.
 ::::

--- a/content/help/guides/troubleshooting-problems.md
+++ b/content/help/guides/troubleshooting-problems.md
@@ -1,0 +1,143 @@
+---
+title: Troubleshooting problems
+description: Encountered an issue with a source or the app? Here are resources to help you troubleshoot it.
+lang: en-US
+---
+
+# Troubleshooting problems
+
+This page is for when you encounter a problem with a source or the app.
+
+::: c-danger Common error messages
+This is just a list of some errors. Go through [Diagnosis](#diagnosis) even if your problem isn't on the list.
+- HTTP Error 4xx
+- HTTP Error 5xx
+- Unexpected URL
+- Page List is empty
+- Unable to resolve host
+- Failed to bypass Cloudflare
+- java.security.cert.CertPathValidatorException
+- Attempt to invoke virtual method 'java.lang.String org.jsoup.nodes.Node.attr(java.lang.String)' on a null object reference
+:::
+
+## Diagnosis
+* Verify your extensions are up to date. (<Navigation item="browse"/> → Extensions, make sure no extensions have an update button)
+* Check if **Tachiyomi** has an update (<Navigation item="more"/> → <Navigation item="about"/> then click **Check for updates**)
+* Try opening the manga in <Navigation item="webview"/>. If there is [CAPTCHA](#solving-a-captcha), solve it and see if it helped.
+* Change your internet connection (*switch to Wi-Fi, mobile data or a VPN, use a "What's my IP" site to confirm your IP has changed*), then try again.
+* Ask other users to try the action that gives you the error.
+* Check if the source is either down, or is having issues in a browser.
+* Press the retry button in the middle of your manga page if one exists.
+* Try the following at <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>
+  * **Clear Cache**
+  * **Clear Cookies**
+  * **Clear Database**
+  * **DNS over HTTPS**
+* If your downloads are getting stuck, try deleting the queue and trying again.
+* Force close **Tachiyomi** and reopen it.
+
+::: c-tip
+Your issue may have been fixed in the Preview version already, just wait for a new Stable release.
+:::
+
+If any of these help, go to [it only happens to me](#it-only-happens-to-me).
+If it's not just you, go to [everyone is having this problem](#everyone-is-having-this-problem).
+
+If none of these help, try asking in our [Discord Server](https://discord.gg/tachiyomi). State app version, source, manga and chapter with the problem.
+
+### It only happens to me
+You may be getting a **CAPTCHA**, may have been IP-banned, or encountered some other counter-measure that website owners deploy against programs like **Tachiyomi**. If that is the case, there is probably nothing that can be done about that. Some of them (like **CAPTCHA**) have to be manually solved, some are temporary (IP bans).
+
+**Workarounds that can lower chance of it happening again:**
+* Don't use downloads with the source.
+* Have less manga in library from the source.
+
+::: c-warning
+All of the above are very imprecise and fuzzy rules, because each site has their own, non-public limits and triggers.
+:::
+
+### Everyone is having this problem
+If the site is reachable and fully functional then there may be an issue with the extension or app.
+1. Have a look at open issues [for the app](https://github.com/inorichi/tachiyomi/issues) and/or [extensions](https://github.com/inorichi/tachiyomi-extensions/issues).
+1. It may have been fixed already, but not released yet, so look at closed issues ([app](https://github.com/inorichi/tachiyomi/issues?q=is%3Aissue+is%3Aclosed) / [extensions](https://github.com/inorichi/tachiyomi-extensions/issues?q=is%3Aissue+is%3Aclosed)) issues as well.
+1. If you can't find the issue there, open a new one.
+
+If the site is not reachable or having issues then all you can do is wait for the site to become functional again.
+
+### What are some common errors?
+
+:::: el-collapse
+::: el-collapse-item title="Java.lang Exception: Challenge not found"
+Often this will be resolved by force-quitting and reopening **Tachiyomi**.
+:::
+::: el-collapse-item title="Loader not implemented"
+It means that the respective extension for the manga is not installed. To fix, install the extension for the manga. If it still doesn't work, uninstall then reinstall the extension again.
+:::
+::: el-collapse-item title="Value Manga is licensed at data of type java.lang.String cannot be converted to JSONObject"
+This means that the manga has been licensed and can no longer be read on that source. Try a different source to read the manga.
+:::
+::: el-collapse-item title="HTTP error 403"
+The source you selected may have **Cloudflare** protection on and is enforcing [CAPTCHA](#solving-a-captcha). Please complete the [CAPTCHA](#solving-a-captcha) to fix it.
+:::
+::: el-collapse-item title="HTTP error 429 (Too Many Requests)"
+The source banned your IP address (in most cases it's temporary). We suggest to [migrate](./source-migration.md) part of your manga to another source.
+:::
+::: el-collapse-item title="HTTP error 5xx"
+Most probably the source you are trying to access has problems on their side. Open the source in <Navigation item="webview"/> and check if the site is down.
+:::
+::: el-collapse-item title="Unable to resolve host / Connection failed"
+That means that something prevents your connection with the site. Possible reasons: your internet connection is bad, the app doesn't have access to internet, your ISP have blocked the site, the site is down. Try using different internet connection (switch to Wi-Fi, mobile data or a VPN). Try to enable <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> → **DNS over HTTPS**.
+:::
+::: el-collapse-item title="java.security.cert.CertPathValidatorException / Chain validation failed"
+That means there is a problem with validating source's sertificate.
+
+- Check if the site's certificate have expired. Use an online service for checking SSL certificates. If the certificate have expired, then wait while the site owner will renew it.
+- Ensure that you have right date and time set on your phone.
+- Try <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> → **Clear cache** and **Clear cookies**.
+- Try using different internet connection (switch to Wi-Fi, mobile data or a VPN).
+- Try to restart the device.
+:::
+::: el-collapse-item title="App not installed"
+You may encounter this if you're installing an official build over an existing **F-Droid** build due to differing signatures.
+Backup your data, uninstall the app, then restore the data in the fresh install.
+:::
+::: el-collapse-item title="Attempt to invoke virtual method 'com.hippo.unifile..."
+This error can be caused by a variety of reasons, all to do with storage.
+
+- Most commonly it is caused by full storage, check to see if your device or SD Card is full.
+- Check if **Tachiyomi** has access to the SD card. You can enable it in the android settings for app permissions.
+- If you're downloading and this error pops up, that means the app might not be able to access the folder you're trying to download to. This may be because the folder is corrupted or does not exist. Use a file manager to check that the folder(s) exist and every folder in the sequence is available and accessible.
+- The drive you're writing to is corrupted. Check using a file manager to see if it is accessible.
+:::
+::: el-collapse-item title="Cannot Access SD Card"
+This error is typically caused by having a file or folder name that is too long. Android's file manager does not support filenames longer than 255 characters. If you know the file or folder name that is the culprit, you can connect your SD card to your computer and shorten it. Otherwise, delete the Tachiyomi downloads folder off of the SD Card.
+:::
+::::
+
+
+## Solving a CAPTCHA
+
+**Please note that WebView is not the same as using your browser.**
+
+You must solve the **CAPTCHA** in **WebView**.
+
+::: guide How to open WebView
+1. Go to <Navigation item="browse"/> in the bottom navbar.
+1. Press the source you'd like to access.
+1. Press the <Navigation item="webview"/> icon.
+	<figure class="centered">
+		<img class="zoomable" :src="$withBase('/assets/guides_webview-open.jpg')">
+	</figure>
+1. Complete **CAPTCHA** if one is present.
+1. Once done, press the *Back Arrow* at the top left to return.
+:::
+
+### WebView not working?
+If **WebView** doesn't work for you, please update the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.WebView) app.
+
+When you've updated go to [Developer Options](https://developer.android.com/studio/debug/dev-options) in your phone's settings and set **WebView Implementation** to `Android System WebView`.
+
+::: c-tip
+If `Android System WebView` doesn't work, try setting `Google Chrome` as the default **WebView Implementation** instead.
+:::
+

--- a/content/help/guides/troubleshooting-problems.md
+++ b/content/help/guides/troubleshooting-problems.md
@@ -21,14 +21,14 @@ This is just a list of some errors. Go through [Diagnosis](#diagnosis) even if y
 :::
 
 ## Diagnosis
-* Verify your extensions are up to date. (<Navigation item="browse"/> → Extensions, make sure no extensions have an update button)
-* Check if **Tachiyomi** has an update (<Navigation item="more"/> → <Navigation item="about"/> then click **Check for updates**)
-* Try opening the manga in <Navigation item="webview"/>. If there is [CAPTCHA](#solving-a-captcha), solve it and see if it helped.
+* Verify your extensions are up to date. (`<Navigation item="browse"/>` → Extensions, make sure no extensions have an update button)
+* Check if **Tachiyomi** has an update (`<Navigation item="more"/> → <Navigation item="about"/>` then click **Check for updates**)
+* Try opening the manga in `<Navigation item="webview"/>`. If there is [CAPTCHA](#solving-a-captcha), solve it and see if it helped.
 * Change your internet connection (*switch to Wi-Fi, mobile data or a VPN, use a "What's my IP" site to confirm your IP has changed*), then try again.
 * Ask other users to try the action that gives you the error.
 * Check if the source is either down, or is having issues in a browser.
 * Press the retry button in the middle of your manga page if one exists.
-* Try the following at <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>
+* Try the following at `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>`
   * **Clear Cache**
   * **Clear Cookies**
   * **Clear Database**
@@ -83,17 +83,17 @@ The source you selected may have **Cloudflare** protection on and is enforcing [
 The source banned your IP address (in most cases it's temporary). We suggest to [migrate](./source-migration.md) part of your manga to another source.
 :::
 ::: el-collapse-item title="HTTP error 5xx"
-Most probably the source you are trying to access has problems on their side. Open the source in <Navigation item="webview"/> and check if the site is down.
+Most probably the source you are trying to access has problems on their side. Open the source in `<Navigation item="webview"/>` and check if the site is down.
 :::
 ::: el-collapse-item title="Unable to resolve host / Connection failed"
-That means that something prevents your connection with the site. Possible reasons: your internet connection is bad, the app doesn't have access to internet, your ISP have blocked the site, the site is down. Try using different internet connection (switch to Wi-Fi, mobile data or a VPN). Try to enable <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> → **DNS over HTTPS**.
+That means that something prevents your connection with the site. Possible reasons: your internet connection is bad, the app doesn't have access to internet, your ISP have blocked the site, the site is down. Try using different internet connection (switch to Wi-Fi, mobile data or a VPN). Try to enable `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>` → **DNS over HTTPS**.
 :::
 ::: el-collapse-item title="java.security.cert.CertPathValidatorException / Chain validation failed"
 That means there is a problem with validating source's sertificate.
 
 - Check if the site's certificate have expired. Use an online service for checking SSL certificates. If the certificate have expired, then wait while the site owner will renew it.
 - Ensure that you have right date and time set on your phone.
-- Try <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> → **Clear cache** and **Clear cookies**.
+- Try `<Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/>` → **Clear cache** and **Clear cookies**.
 - Try using different internet connection (switch to Wi-Fi, mobile data or a VPN).
 - Try to restart the device.
 :::
@@ -122,9 +122,9 @@ This error is typically caused by having a file or folder name that is too long.
 You must solve the **CAPTCHA** in **WebView**.
 
 ::: guide How to open WebView
-1. Go to <Navigation item="browse"/> in the bottom navbar.
+1. Go to `<Navigation item="browse"/>` in the bottom navbar.
 1. Press the source you'd like to access.
-1. Press the <Navigation item="webview"/> icon.
+1. Press the `<Navigation item="webview"/>` icon.
 	<figure class="centered">
 		<img class="zoomable" :src="$withBase('/assets/guides_webview-open.jpg')">
 	</figure>

--- a/content/help/index.md
+++ b/content/help/index.md
@@ -1,5 +1,4 @@
 ---
-layout: Help
 title: Help Center
 description: From common questions to guides, find help for everything Tachiyomi.
 next: '/download/'

--- a/content/help/index.md
+++ b/content/help/index.md
@@ -1,9 +1,49 @@
 ---
-description: ''
+layout: Help
+title: Help Center
+description: From common questions to guides, find help for everything Tachiyomi.
 next: '/download/'
+lang: en-US
+hideSearch: true
+help:
+  - title: Application
+    description: Frequently asked questions
+    link: /help/faq/#application
+    faqApp: true
+  - title: Extensions
+    description: Frequently asked questions
+    link: /help/faq/#extensions
+    faqExt: true
+  - title: Guides
+    description: Extensive guides written for you
+    link: /help/guides/getting-started/
+    guides: true
+    extensions: true
+  - title: Forks
+    description: Alternative versions
+    link: /forks/
+    forks: true
+  - title: Contribution
+    description: Help contribute to the app
+    link: /help/contribution/
+    contribution: true
+  - title: Discord
+    description: Primary communication platform
+    linkExt: https://discord.gg/tachiyomi
+    discord: true
+  - title: Reddit
+    description: Community forums
+    linkExt: https://reddit.com/r/Tachiyomi
+    reddit: true
+  - title: GitHub
+    description: Repository for the app
+    linkExt: https://github.com/inorichi/tachiyomi
+    github: true
 ---
 
 # Help Center
 
-## Need help? We've got your back.
+::: slot center
+### Need help? We've got your back.
 From common questions to guides, find help for everything Tachiyomi.
+:::

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -87,6 +87,14 @@ module.exports = {
       use: '@gridsome/plugin-sitemap',
       options: {
       }
+    },
+    {
+      use: '@gridsome/vue-remark',
+      options: {
+        typeName: 'MarkdownPage',
+        baseDir: './content',
+        template: './src/templates/MarkdownPage.vue'
+      }
     }
 
   ]

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -47,22 +47,22 @@ module.exports = {
     ]
   },
   plugins: [
-    {
-      use: '@gridsome/source-filesystem',
-      options: {
-        baseDir: './content',
-        path: '**/*.md',
-        typeName: 'MarkdownPage',
-        remark: {
-          externalLinksTarget: '_blank',
-          externalLinksRel: ['noopener', 'noreferrer'],
-          plugins: [
-            '@gridsome/remark-prismjs'
-          ]
-        }
-      }
-    },
-
+    // This seems to be replace by @gridsome/vue-remark
+    // { 
+    //   use: '@gridsome/source-filesystem',
+    //   options: {
+    //     baseDir: './content',
+    //     path: '**/*.md',
+    //     typeName: 'MarkdownPage',
+    //     remark: {
+    //       externalLinksTarget: '_blank',
+    //       externalLinksRel: ['noopener', 'noreferrer'],
+    //       plugins: [
+    //         '@gridsome/remark-prismjs'
+    //       ]
+    //     }
+    //   }
+    // },
     {
       use: 'gridsome-plugin-tailwindcss',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,7 +1025,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@gridsome/source-filesystem/-/source-filesystem-0.6.2.tgz",
       "integrity": "sha512-K1pyXwFYIlABaHq3wqOPyYt4ARzLZuUQ+UZKjDSBT9I0T0qpCbwir5kJMQkR7qY4ONflUrv8fgG6DNSrc1uzbA==",
-      "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
         "fs-extra": "^7.0.0",
@@ -1074,6 +1073,120 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
+        }
+      }
+    },
+    "@gridsome/vue-remark": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@gridsome/vue-remark/-/vue-remark-0.2.6.tgz",
+      "integrity": "sha512-WmClays+S+TtsYuxNo8OyV+OXo3ALt+oFyoATMOH+f7tcocXlXDPGcGZwrFFAAfyDrAPqpkFVL31jGIy5hR0kA==",
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/preset-env": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@gridsome/source-filesystem": "^0.6.2",
+        "@gridsome/transformer-remark": "^0.6.4",
+        "hash-sum": "^1.0.2",
+        "hast-util-to-html": "^5.0.0",
+        "he": "^1.2.0",
+        "html-tags": "^3.1.0",
+        "is-relative": "^1.0.0",
+        "is-url": "^1.2.4",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.11",
+        "lru-cache": "^5.1.1",
+        "mdast-util-to-hast": "^4.0.0",
+        "moment": "^2.24.0",
+        "path-to-regexp": "^3.1.0",
+        "unist-builder": "^1.0.3",
+        "unist-util-visit": "^1.4.0"
+      },
+      "dependencies": {
+        "@gridsome/transformer-remark": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/@gridsome/transformer-remark/-/transformer-remark-0.6.4.tgz",
+          "integrity": "sha512-DCRQn1KFLk9Iy+ZjhDdYoTOYhEBphP57dRsLkhLqcnbuMCttDcI6V9udUR6GHgWWN3h0XV2dGVXcQ056Xm9Hpg==",
+          "requires": {
+            "gray-matter": "^4.0.2",
+            "hash-sum": "^1.0.2",
+            "lodash": "^4.17.11",
+            "lru-cache": "^5.1.1",
+            "remark-autolink-headings": "^5.0.0",
+            "remark-external-links": "^3.0.0",
+            "remark-fix-guillemets": "^1.0.15",
+            "remark-html": "^8.0.0",
+            "remark-parse": "^6.0.0",
+            "remark-slug": "^4.2.3",
+            "remark-squeeze-paragraphs": "^3.0.2",
+            "sanitize-html": "^1.20.0",
+            "unified": "^7.0.0",
+            "unist-util-visit": "^1.4.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "hast-util-to-html": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-5.0.1.tgz",
+          "integrity": "sha512-zPuZuclFMJAP50wi9FoP3fcjOWmP3A9CqiPiR1nqOoweYDB4Urc2tg4ZITeDOrOjUQG5zArGopeGDuu3+vkGQg==",
+          "requires": {
+            "ccount": "^1.0.0",
+            "comma-separated-tokens": "^1.0.1",
+            "hast-util-is-element": "^1.0.0",
+            "hast-util-whitespace": "^1.0.0",
+            "html-void-elements": "^1.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0",
+            "stringify-entities": "^1.0.1",
+            "unist-util-is": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "html-tags": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+          "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
+          "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "detab": "^2.0.0",
+            "mdast-util-definitions": "^1.2.0",
+            "mdurl": "^1.0.1",
+            "trim": "0.0.1",
+            "trim-lines": "^1.0.0",
+            "unist-builder": "^1.0.1",
+            "unist-util-generated": "^1.1.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^1.1.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "path-to-regexp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+        },
+        "unist-util-is": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -1238,14 +1351,12 @@
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-      "dev": true
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/vfile": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
       "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/unist": "*",
@@ -1256,7 +1367,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
       "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
-      "dev": true,
       "requires": {
         "vfile-message": "*"
       }
@@ -1971,8 +2081,7 @@
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2719,8 +2828,7 @@
     "ccount": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
-      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
-      "dev": true
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -2735,26 +2843,22 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-html4": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
-      "dev": true
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chokidar": {
       "version": "2.1.8",
@@ -2899,8 +3003,7 @@
     "collapse-white-space": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-      "dev": true
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2969,8 +3072,7 @@
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "2.20.3",
@@ -3778,7 +3880,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
       "integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
-      "dev": true,
       "requires": {
         "repeat-string": "^1.5.4"
       }
@@ -3857,6 +3958,11 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -3871,7 +3977,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
       "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1"
       },
@@ -3879,8 +3984,7 @@
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         }
       }
     },
@@ -3976,8 +4080,7 @@
     "emoji-regex": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-      "dev": true
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -4799,7 +4902,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
       "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
-      "dev": true,
       "requires": {
         "emoji-regex": ">=6.0.0 <=6.1.1"
       }
@@ -4840,6 +4942,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -4981,7 +5092,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
       "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
-      "dev": true,
       "requires": {
         "js-yaml": "^3.11.0",
         "kind-of": "^6.0.2",
@@ -5258,8 +5368,7 @@
     "hast-util-is-element": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
-      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==",
-      "dev": true
+      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA=="
     },
     "hast-util-parse-selector": {
       "version": "2.2.3",
@@ -5271,7 +5380,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
       "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-      "dev": true,
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -5280,7 +5388,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz",
       "integrity": "sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==",
-      "dev": true,
       "requires": {
         "ccount": "^1.0.0",
         "comma-separated-tokens": "^1.0.1",
@@ -5298,7 +5405,6 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
           "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-          "dev": true,
           "requires": {
             "xtend": "^4.0.1"
           }
@@ -5306,16 +5412,14 @@
         "unist-util-is": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
-          "dev": true
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
         }
       }
     },
     "hast-util-whitespace": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.3.tgz",
-      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA==",
-      "dev": true
+      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA=="
     },
     "hastscript": {
       "version": "5.1.1",
@@ -5420,8 +5524,7 @@
     "html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
-      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
-      "dev": true
+      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
@@ -5812,14 +5915,12 @@
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -5900,8 +6001,7 @@
     "is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -5949,8 +6049,7 @@
     "is-hexadecimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -6103,8 +6202,7 @@
     "is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-      "dev": true
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6114,8 +6212,7 @@
     "is-word-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-      "dev": true
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -6393,8 +6490,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.deburr": {
       "version": "4.1.0",
@@ -6404,20 +6500,17 @@
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
-      "dev": true
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -6432,8 +6525,7 @@
     "lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -6624,8 +6716,7 @@
     "markdown-escapes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-      "dev": true
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
     },
     "md5-file": {
       "version": "4.0.0",
@@ -6646,7 +6737,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
       "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
-      "dev": true,
       "requires": {
         "unist-util-remove": "^1.0.0"
       }
@@ -6655,7 +6745,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
       "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "dev": true,
       "requires": {
         "unist-util-visit": "^1.0.0"
       }
@@ -6664,7 +6753,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
       "integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
-      "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -6682,8 +6770,7 @@
     "mdast-util-to-string": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.8.tgz",
-      "integrity": "sha512-GBracya0dOzckEEizUBzfrkWRLCHMsppuU97LPUriY9kWnYyGFWTx4VDW+sUcj2LneBz/Tp1aYp3aUCibzjtWg==",
-      "dev": true
+      "integrity": "sha512-GBracya0dOzckEEizUBzfrkWRLCHMsppuU97LPUriY9kWnYyGFWTx4VDW+sUcj2LneBz/Tp1aYp3aUCibzjtWg=="
     },
     "mdn-data": {
       "version": "2.0.4",
@@ -6693,8 +6780,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6842,6 +6928,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
@@ -7728,7 +7822,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
       "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -8928,7 +9021,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
       "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
-      "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -9351,7 +9443,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/remark-autolink-headings/-/remark-autolink-headings-5.2.1.tgz",
       "integrity": "sha512-pAsIVtbYWIkCDoR/hXJQAjXRnzQ5hjQzmiz2eQnZMIQbsiut3x5xEQYF+urpNEQSUG1/I+9wp2sSERgaxiaBdQ==",
-      "dev": true,
       "requires": {
         "extend": "^3.0.2",
         "unist-util-visit": "^1.0.1"
@@ -9361,7 +9452,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-3.1.1.tgz",
       "integrity": "sha512-QeqEeThumJ6GJzzgP45XY7+C6IGdvRxy8WkJNL/jRaeiGLDxmBUx0ggFIm5N5tHU3O8KbUrxM4tZgAHb53hddg==",
-      "dev": true,
       "requires": {
         "is-absolute-url": "^2.1.0",
         "mdast-util-definitions": "^1.2.3",
@@ -9373,7 +9463,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.0.tgz",
       "integrity": "sha512-Cn4TyeXlyMajqdYjbFf9b76Ozffx/tvyr9m4Q9sypoGZ/CMA+du+kLE54T+j+5n9asEU7+cpiSZTimD4s+1Izg==",
-      "dev": true,
       "requires": {
         "unist-util-visit": "^2.0.1"
       },
@@ -9381,14 +9470,12 @@
         "unist-util-is": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
-          "dev": true
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
         },
         "unist-util-visit": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
           "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
-          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0",
@@ -9399,7 +9486,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
           "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
-          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0"
@@ -9411,7 +9497,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-8.0.0.tgz",
       "integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
-      "dev": true,
       "requires": {
         "hast-util-sanitize": "^1.0.0",
         "hast-util-to-html": "^4.0.0",
@@ -9423,7 +9508,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
       "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
-      "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -9446,7 +9530,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-4.2.3.tgz",
       "integrity": "sha1-jZh9Dl5j1KSeo3uQ/pmaPc/IG3I=",
-      "dev": true,
       "requires": {
         "github-slugger": "^1.0.0",
         "mdast-util-to-string": "^1.0.0",
@@ -9457,7 +9540,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
       "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
-      "dev": true,
       "requires": {
         "mdast-squeeze-paragraphs": "^3.0.0"
       }
@@ -9668,7 +9750,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.22.0.tgz",
       "integrity": "sha512-3RPo65mbTKpOAdAYWU496MSty1YbB3Y5bjwL5OclgaSSMtv65xvM7RW/EHRumzaZ1UddEJowCbSdK0xl5sAu0A==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "htmlparser2": "^4.1.0",
@@ -9685,14 +9766,12 @@
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         },
         "domutils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
           "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
-          "dev": true,
           "requires": {
             "dom-serializer": "^0.2.1",
             "domelementtype": "^2.0.1",
@@ -9703,7 +9782,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
           "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-          "dev": true,
           "requires": {
             "domelementtype": "^2.0.1",
             "domhandler": "^3.0.0",
@@ -9796,7 +9874,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -10335,8 +10412,7 @@
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -10435,8 +10511,7 @@
     "srcset": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-2.0.1.tgz",
-      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==",
-      "dev": true
+      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ=="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -10480,8 +10555,7 @@
     "state-toggle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-      "dev": true
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -10604,7 +10678,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-      "dev": true,
       "requires": {
         "character-entities-html4": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -10631,8 +10704,7 @@
     "strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-      "dev": true
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -11081,14 +11153,12 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-lines": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-      "dev": true
+      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA=="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -11106,14 +11176,12 @@
     "trim-trailing-lines": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
-      "dev": true
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
     },
     "trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
     },
     "true-case-path": {
       "version": "1.0.3",
@@ -11211,7 +11279,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
       "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.0",
         "xtend": "^4.0.0"
@@ -11245,7 +11312,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
       "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "@types/vfile": "^3.0.0",
@@ -11260,14 +11326,12 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "vfile": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
           "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
-          "dev": true,
           "requires": {
             "is-buffer": "^2.0.0",
             "replace-ext": "1.0.0",
@@ -11279,7 +11343,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
           "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-          "dev": true,
           "requires": {
             "unist-util-stringify-position": "^1.1.1"
           }
@@ -11335,7 +11398,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
       "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "dev": true,
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -11343,26 +11405,22 @@
     "unist-util-generated": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
-      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==",
-      "dev": true
+      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
     },
     "unist-util-is": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "dev": true
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
     },
     "unist-util-position": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "dev": true
+      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
     },
     "unist-util-remove": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
       "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
-      "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
       }
@@ -11371,7 +11429,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
       "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-      "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
@@ -11379,14 +11436,12 @@
     "unist-util-stringify-position": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-      "dev": true
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
     },
     "unist-util-visit": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
       "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       }
@@ -11395,7 +11450,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
       }
@@ -11638,7 +11692,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
       "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -11650,14 +11703,12 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "unist-util-stringify-position": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
           "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
-          "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
           }
@@ -11667,14 +11718,12 @@
     "vfile-location": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-      "dev": true
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
     },
     "vfile-message": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
       "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
@@ -11684,7 +11733,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
           "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
-          "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
           }
@@ -11706,6 +11754,23 @@
       "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz",
       "integrity": "sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==",
       "dev": true
+    },
+    "vue-carousel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/vue-carousel/-/vue-carousel-0.18.0.tgz",
+      "integrity": "sha512-a2zxh7QJioDxNMguqcuJ7TPbfgK5bGDaAXIia7NWxPAWsEvNE4ZtHgsGu40L5Aha4uyjmNKXvleB14QAXFoKig==",
+      "requires": {
+        "global": "^4.3.2",
+        "regenerator-runtime": "^0.12.1",
+        "vue": "^2.5.17"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
     },
     "vue-feather-icons": {
       "version": "5.0.0",
@@ -12089,8 +12154,7 @@
     "x-is-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-      "dev": true
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,6 +1025,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@gridsome/source-filesystem/-/source-filesystem-0.6.2.tgz",
       "integrity": "sha512-K1pyXwFYIlABaHq3wqOPyYt4ARzLZuUQ+UZKjDSBT9I0T0qpCbwir5kJMQkR7qY4ONflUrv8fgG6DNSrc1uzbA==",
+      "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
         "fs-extra": "^7.0.0",
@@ -1080,6 +1081,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@gridsome/vue-remark/-/vue-remark-0.2.6.tgz",
       "integrity": "sha512-WmClays+S+TtsYuxNo8OyV+OXo3ALt+oFyoATMOH+f7tcocXlXDPGcGZwrFFAAfyDrAPqpkFVL31jGIy5hR0kA==",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/parser": "^7.0.0",
@@ -1107,6 +1109,7 @@
           "version": "0.6.4",
           "resolved": "https://registry.npmjs.org/@gridsome/transformer-remark/-/transformer-remark-0.6.4.tgz",
           "integrity": "sha512-DCRQn1KFLk9Iy+ZjhDdYoTOYhEBphP57dRsLkhLqcnbuMCttDcI6V9udUR6GHgWWN3h0XV2dGVXcQ056Xm9Hpg==",
+          "dev": true,
           "requires": {
             "gray-matter": "^4.0.2",
             "hash-sum": "^1.0.2",
@@ -1129,6 +1132,7 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-5.0.1.tgz",
           "integrity": "sha512-zPuZuclFMJAP50wi9FoP3fcjOWmP3A9CqiPiR1nqOoweYDB4Urc2tg4ZITeDOrOjUQG5zArGopeGDuu3+vkGQg==",
+          "dev": true,
           "requires": {
             "ccount": "^1.0.0",
             "comma-separated-tokens": "^1.0.1",
@@ -1145,12 +1149,14 @@
         "html-tags": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-          "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+          "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+          "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -1159,6 +1165,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
           "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+          "dev": true,
           "requires": {
             "collapse-white-space": "^1.0.0",
             "detab": "^2.0.0",
@@ -1176,17 +1183,20 @@
         "path-to-regexp": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+          "dev": true
         },
         "unist-util-is": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
@@ -1351,12 +1361,14 @@
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
     },
     "@types/vfile": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
       "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/unist": "*",
@@ -1367,6 +1379,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
       "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
+      "dev": true,
       "requires": {
         "vfile-message": "*"
       }
@@ -2081,7 +2094,8 @@
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2828,7 +2842,8 @@
     "ccount": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
-      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -2843,22 +2858,26 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true
     },
     "character-entities-html4": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
+      "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true
     },
     "character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
@@ -3003,7 +3022,8 @@
     "collapse-white-space": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3072,7 +3092,8 @@
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "dev": true
     },
     "commander": {
       "version": "2.20.3",
@@ -3880,6 +3901,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
       "integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
+      "dev": true,
       "requires": {
         "repeat-string": "^1.5.4"
       }
@@ -3977,6 +3999,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
       "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1"
       },
@@ -3984,7 +4007,8 @@
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
         }
       }
     },
@@ -4080,7 +4104,8 @@
     "emoji-regex": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
+      "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -4902,6 +4927,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
       "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "dev": true,
       "requires": {
         "emoji-regex": ">=6.0.0 <=6.1.1"
       }
@@ -5092,6 +5118,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
       "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
+      "dev": true,
       "requires": {
         "js-yaml": "^3.11.0",
         "kind-of": "^6.0.2",
@@ -5368,7 +5395,8 @@
     "hast-util-is-element": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
-      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA=="
+      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==",
+      "dev": true
     },
     "hast-util-parse-selector": {
       "version": "2.2.3",
@@ -5380,6 +5408,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
       "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
+      "dev": true,
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -5388,6 +5417,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz",
       "integrity": "sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==",
+      "dev": true,
       "requires": {
         "ccount": "^1.0.0",
         "comma-separated-tokens": "^1.0.1",
@@ -5405,6 +5435,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
           "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
+          "dev": true,
           "requires": {
             "xtend": "^4.0.1"
           }
@@ -5412,14 +5443,16 @@
         "unist-util-is": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
+          "dev": true
         }
       }
     },
     "hast-util-whitespace": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.3.tgz",
-      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA=="
+      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA==",
+      "dev": true
     },
     "hastscript": {
       "version": "5.1.1",
@@ -5524,7 +5557,8 @@
     "html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
-      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
+      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
+      "dev": true
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
@@ -5915,12 +5949,14 @@
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true
     },
     "is-alphanumerical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -6001,7 +6037,8 @@
     "is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -6049,7 +6086,8 @@
     "is-hexadecimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -6202,7 +6240,8 @@
     "is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6212,7 +6251,8 @@
     "is-word-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+      "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -6490,7 +6530,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.deburr": {
       "version": "4.1.0",
@@ -6500,17 +6541,20 @@
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -6525,7 +6569,8 @@
     "lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -6716,7 +6761,8 @@
     "markdown-escapes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+      "dev": true
     },
     "md5-file": {
       "version": "4.0.0",
@@ -6737,6 +6783,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
       "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
+      "dev": true,
       "requires": {
         "unist-util-remove": "^1.0.0"
       }
@@ -6745,6 +6792,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
       "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
+      "dev": true,
       "requires": {
         "unist-util-visit": "^1.0.0"
       }
@@ -6753,6 +6801,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
       "integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
+      "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -6770,7 +6819,8 @@
     "mdast-util-to-string": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.8.tgz",
-      "integrity": "sha512-GBracya0dOzckEEizUBzfrkWRLCHMsppuU97LPUriY9kWnYyGFWTx4VDW+sUcj2LneBz/Tp1aYp3aUCibzjtWg=="
+      "integrity": "sha512-GBracya0dOzckEEizUBzfrkWRLCHMsppuU97LPUriY9kWnYyGFWTx4VDW+sUcj2LneBz/Tp1aYp3aUCibzjtWg==",
+      "dev": true
     },
     "mdn-data": {
       "version": "2.0.4",
@@ -6780,7 +6830,8 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -7822,6 +7873,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
       "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -9021,6 +9073,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
       "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
+      "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -9443,6 +9496,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/remark-autolink-headings/-/remark-autolink-headings-5.2.1.tgz",
       "integrity": "sha512-pAsIVtbYWIkCDoR/hXJQAjXRnzQ5hjQzmiz2eQnZMIQbsiut3x5xEQYF+urpNEQSUG1/I+9wp2sSERgaxiaBdQ==",
+      "dev": true,
       "requires": {
         "extend": "^3.0.2",
         "unist-util-visit": "^1.0.1"
@@ -9452,6 +9506,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-3.1.1.tgz",
       "integrity": "sha512-QeqEeThumJ6GJzzgP45XY7+C6IGdvRxy8WkJNL/jRaeiGLDxmBUx0ggFIm5N5tHU3O8KbUrxM4tZgAHb53hddg==",
+      "dev": true,
       "requires": {
         "is-absolute-url": "^2.1.0",
         "mdast-util-definitions": "^1.2.3",
@@ -9463,6 +9518,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.0.tgz",
       "integrity": "sha512-Cn4TyeXlyMajqdYjbFf9b76Ozffx/tvyr9m4Q9sypoGZ/CMA+du+kLE54T+j+5n9asEU7+cpiSZTimD4s+1Izg==",
+      "dev": true,
       "requires": {
         "unist-util-visit": "^2.0.1"
       },
@@ -9470,12 +9526,14 @@
         "unist-util-is": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
+          "dev": true
         },
         "unist-util-visit": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
           "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0",
@@ -9486,6 +9544,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
           "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0"
@@ -9497,6 +9556,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-8.0.0.tgz",
       "integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
+      "dev": true,
       "requires": {
         "hast-util-sanitize": "^1.0.0",
         "hast-util-to-html": "^4.0.0",
@@ -9508,6 +9568,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
       "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -9530,6 +9591,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-4.2.3.tgz",
       "integrity": "sha1-jZh9Dl5j1KSeo3uQ/pmaPc/IG3I=",
+      "dev": true,
       "requires": {
         "github-slugger": "^1.0.0",
         "mdast-util-to-string": "^1.0.0",
@@ -9540,6 +9602,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
       "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
+      "dev": true,
       "requires": {
         "mdast-squeeze-paragraphs": "^3.0.0"
       }
@@ -9750,6 +9813,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.22.0.tgz",
       "integrity": "sha512-3RPo65mbTKpOAdAYWU496MSty1YbB3Y5bjwL5OclgaSSMtv65xvM7RW/EHRumzaZ1UddEJowCbSdK0xl5sAu0A==",
+      "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "htmlparser2": "^4.1.0",
@@ -9766,12 +9830,14 @@
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
         },
         "domutils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
           "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "dev": true,
           "requires": {
             "dom-serializer": "^0.2.1",
             "domelementtype": "^2.0.1",
@@ -9782,6 +9848,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
           "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "dev": true,
           "requires": {
             "domelementtype": "^2.0.1",
             "domhandler": "^3.0.0",
@@ -9874,6 +9941,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -10412,7 +10480,8 @@
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -10511,7 +10580,8 @@
     "srcset": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-2.0.1.tgz",
-      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ=="
+      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -10555,7 +10625,8 @@
     "state-toggle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -10678,6 +10749,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "dev": true,
       "requires": {
         "character-entities-html4": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -10704,7 +10776,8 @@
     "strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -11153,12 +11226,14 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
     },
     "trim-lines": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA=="
+      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -11176,12 +11251,14 @@
     "trim-trailing-lines": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
+      "dev": true
     },
     "trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
     },
     "true-case-path": {
       "version": "1.0.3",
@@ -11279,6 +11356,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
       "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.0",
         "xtend": "^4.0.0"
@@ -11312,6 +11390,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
       "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "@types/vfile": "^3.0.0",
@@ -11326,12 +11405,14 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         },
         "vfile": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
           "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "dev": true,
           "requires": {
             "is-buffer": "^2.0.0",
             "replace-ext": "1.0.0",
@@ -11343,6 +11424,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
           "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "dev": true,
           "requires": {
             "unist-util-stringify-position": "^1.1.1"
           }
@@ -11398,6 +11480,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
       "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -11405,22 +11488,26 @@
     "unist-util-generated": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
-      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
+      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==",
+      "dev": true
     },
     "unist-util-is": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "dev": true
     },
     "unist-util-position": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
+      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
+      "dev": true
     },
     "unist-util-remove": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
       "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
+      "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
       }
@@ -11429,6 +11516,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
       "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
@@ -11436,12 +11524,14 @@
     "unist-util-stringify-position": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+      "dev": true
     },
     "unist-util-visit": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
       "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       }
@@ -11450,6 +11540,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
       }
@@ -11692,6 +11783,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
       "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -11703,12 +11795,14 @@
         "is-buffer": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         },
         "unist-util-stringify-position": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
           "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
           }
@@ -11718,12 +11812,14 @@
     "vfile-location": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "dev": true
     },
     "vfile-message": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
       "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
+      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
@@ -11733,6 +11829,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
           "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
           }
@@ -12154,7 +12251,8 @@
     "x-is-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13518 +1,20 @@
 {
   "name": "tachiyomi-website",
-  "lockfileVersion": 2,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "tachiyomi-website",
-      "dependencies": {
-        "axios": "^0.21.0",
-        "gridsome": "^0.7.0"
-      },
-      "devDependencies": {
-        "@gridsome/plugin-google-analytics": "^0.1.0",
-        "@gridsome/plugin-sitemap": "^0.2.3",
-        "@gridsome/remark-prismjs": "^0.3.0",
-        "@gridsome/source-filesystem": "^0.6.2",
-        "@gridsome/transformer-remark": "^0.5.0",
-        "fuse.js": "^3.4.6",
-        "gridsome-plugin-tailwindcss": "^2.2.36",
-        "node-sass": "^4.13.1",
-        "prism-themes": "^1.3.0",
-        "sass-loader": "^8.0.2",
-        "tailwindcss": "^1.2.0",
-        "vue-feather-icons": "^5.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.8.5",
-        "invariant": "^2.2.4",
-        "semver": "^5.5.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
-        "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.4",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.13",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/core/node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-explode-assignable-expression": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-call-delegate": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-hoist-variables": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.8.4",
-        "browserslist": "^4.8.5",
-        "invariant": "^2.2.4",
-        "levenary": "^1.1.1",
-        "semver": "^5.5.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-regex": "^7.8.3",
-        "regexpu-core": "^4.6.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-map": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
-      }
-    },
-    "node_modules/@babel/helper-explode-assignable-expression": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-simple-access": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.8.3",
-      "license": "MIT"
-    },
-    "node_modules/@babel/helper-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.13"
-      }
-    },
-    "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-wrap-function": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helper-wrap-function": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-remap-async-to-generator": "^7.8.3",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-decorators": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-remap-async-to-generator": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-define-map": "^7.8.3",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "globals": "^11.1.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-hoist-variables": "^7.8.3",
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-call-delegate": "^7.8.3",
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-transform": "^0.14.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-regex": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.8.4",
-        "@babel/helper-compilation-targets": "^7.8.4",
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-        "@babel/plugin-proposal-json-strings": "^7.8.3",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3",
-        "@babel/plugin-transform-arrow-functions": "^7.8.3",
-        "@babel/plugin-transform-async-to-generator": "^7.8.3",
-        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-        "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@babel/plugin-transform-classes": "^7.8.3",
-        "@babel/plugin-transform-computed-properties": "^7.8.3",
-        "@babel/plugin-transform-destructuring": "^7.8.3",
-        "@babel/plugin-transform-dotall-regex": "^7.8.3",
-        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
-        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-        "@babel/plugin-transform-for-of": "^7.8.4",
-        "@babel/plugin-transform-function-name": "^7.8.3",
-        "@babel/plugin-transform-literals": "^7.8.3",
-        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-        "@babel/plugin-transform-modules-amd": "^7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-        "@babel/plugin-transform-modules-umd": "^7.8.3",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-        "@babel/plugin-transform-new-target": "^7.8.3",
-        "@babel/plugin-transform-object-super": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.8.4",
-        "@babel/plugin-transform-property-literals": "^7.8.3",
-        "@babel/plugin-transform-regenerator": "^7.8.3",
-        "@babel/plugin-transform-reserved-words": "^7.8.3",
-        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
-        "@babel/plugin-transform-spread": "^7.8.3",
-        "@babel/plugin-transform-sticky-regex": "^7.8.3",
-        "@babel/plugin-transform-template-literals": "^7.8.3",
-        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
-        "@babel/plugin-transform-unicode-regex": "^7.8.3",
-        "@babel/types": "^7.8.3",
-        "browserslist": "^4.8.5",
-        "core-js-compat": "^3.6.2",
-        "invariant": "^2.2.2",
-        "levenary": "^1.1.1",
-        "semver": "^5.5.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.8.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.4",
-        "@babel/types": "^7.8.3",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@csstools/convert-colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "7.0.27",
-        "purgecss": "^2.1.0"
-      }
-    },
-    "node_modules/@gridsome/cli": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@hjvedvik/tasks": "^0.0.8",
-        "chalk": "^2.4.1",
-        "commander": "^2.15.1",
-        "didyoumean": "^1.2.1",
-        "envinfo": "^7.3.1",
-        "execa": "^0.10.0",
-        "find-up": "^2.1.0",
-        "fs-extra": "^6.0.1",
-        "resolve-cwd": "^2.0.0",
-        "semver": "^5.6.0",
-        "sort-package-json": "^1.15.0",
-        "update-notifier": "^3.0.1"
-      },
-      "bin": {
-        "gridsome": "bin/gridsome.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@gridsome/cli/node_modules/execa": {
-      "version": "0.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@gridsome/cli/node_modules/fs-extra": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/@gridsome/plugin-google-analytics": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vue-analytics": "^5.16.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@gridsome/plugin-sitemap": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^7.0.0",
-        "micromatch": "^3.1.10",
-        "sitemap": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
-    "node_modules/@gridsome/remark-prismjs": {
-      "version": "0.3.0",
-      "dev": true,
-      "dependencies": {
-        "escape-html": "^1.0.3",
-        "hast-util-to-html": "^6.0.2",
-        "hastscript": "^5.1.0",
-        "prismjs": "^1.15.0",
-        "unist-builder": "^1.0.4",
-        "unist-util-visit": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@gridsome/remark-prismjs/node_modules/hast-util-to-html": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "property-information": "^5.2.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^2.0.0",
-        "unist-util-is": "^3.0.0",
-        "xtend": "^4.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@gridsome/remark-prismjs/node_modules/stringify-entities": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.2",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/@gridsome/source-filesystem": {
-      "version": "0.6.2",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^2.0.4",
-        "fs-extra": "^7.0.0",
-        "globby": "^8.0.1",
-        "lodash": "^4.17.10",
-        "mime-types": "^2.1.21",
-        "slash": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@gridsome/transformer-remark": {
-      "version": "0.5.0",
-      "dev": true,
-      "dependencies": {
-        "gray-matter": "^4.0.2",
-        "hash-sum": "^1.0.2",
-        "hast-util-to-html": "^4.0.1",
-        "html-to-text": "^4.0.0",
-        "lodash": "^4.17.11",
-        "lru-cache": "^5.1.1",
-        "remark-autolink-headings": "^5.0.0",
-        "remark-external-links": "^3.0.0",
-        "remark-fix-guillemets": "^1.0.15",
-        "remark-html": "^8.0.0",
-        "remark-parse": "^6.0.0",
-        "remark-slug": "^4.2.3",
-        "remark-squeeze-paragraphs": "^3.0.2",
-        "sanitize-html": "^1.20.0",
-        "unified": "^7.0.0",
-        "unist-util-visit": "^1.4.0",
-        "vfile": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "gridsome": "0.x"
-      }
-    },
-    "node_modules/@gridsome/transformer-remark/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@gridsome/transformer-remark/node_modules/yallist": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@hapi/address": {
-      "version": "2.1.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/bourne": {
-      "version": "1.3.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "8.5.1",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/joi": {
-      "version": "15.1.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
-      }
-    },
-    "node_modules/@hapi/topo": {
-      "version": "3.1.6",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^8.3.0"
-      }
-    },
-    "node_modules/@hjvedvik/tasks": {
-      "version": "0.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "dateformat": "^3.0.3",
-        "figures": "^2.0.0",
-        "hirestime": "^3.2.1",
-        "log-update": "^2.3.0",
-        "p-map": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@hjvedvik/tasks/node_modules/p-map": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.3",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.3",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sindresorhus/slugify": {
-      "version": "0.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "lodash.deburr": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/events": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/@types/glob": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "13.7.6",
-      "license": "MIT"
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/q": {
-      "version": "1.5.2",
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "16.9.23",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
-    "node_modules/@types/unist": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/vfile": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/unist": "*",
-        "@types/vfile-message": "*"
-      }
-    },
-    "node_modules/@types/vfile-message": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vfile-message": "*"
-      }
-    },
-    "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/@vue/babel-plugin-transform-vue-jsx": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
-        "html-tags": "^2.0.0",
-        "lodash.kebabcase": "^4.1.1",
-        "svg-tags": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-preset-app": {
-      "version": "4.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.8.4",
-        "@babel/helper-compilation-targets": "^7.8.4",
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/plugin-proposal-class-properties": "^7.8.3",
-        "@babel/plugin-proposal-decorators": "^7.8.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-jsx": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.8.3",
-        "@babel/preset-env": "^7.8.4",
-        "@babel/runtime": "^7.8.4",
-        "@vue/babel-preset-jsx": "^1.1.2",
-        "babel-plugin-dynamic-import-node": "^2.3.0",
-        "core-js": "^3.6.4",
-        "core-js-compat": "^3.6.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@vue/babel-preset-jsx": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
-        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
-        "@vue/babel-sugar-functional-vue": "^1.1.2",
-        "@vue/babel-sugar-inject-h": "^1.1.2",
-        "@vue/babel-sugar-v-model": "^1.1.2",
-        "@vue/babel-sugar-v-on": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-sugar-functional-vue": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-sugar-inject-h": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-sugar-v-model": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
-        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
-        "camelcase": "^5.0.0",
-        "html-tags": "^2.0.0",
-        "svg-tags": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/babel-sugar-v-on": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
-        "camelcase": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@vue/component-compiler-utils": {
-      "version": "2.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "consolidate": "^0.15.1",
-        "hash-sum": "^1.0.2",
-        "lru-cache": "^4.1.2",
-        "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.14",
-        "postcss-selector-parser": "^5.0.0",
-        "prettier": "1.16.3",
-        "source-map": "~0.6.1",
-        "vue-template-es2015-compiler": "^1.9.0"
-      }
-    },
-    "node_modules/@vue/component-compiler-utils/node_modules/cssesc": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/component-compiler-utils/node_modules/postcss-selector-parser": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.8.5",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.8.5",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-code-frame": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/wast-printer": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-fsm": {
-      "version": "1.8.5",
-      "license": "ISC"
-    },
-    "node_modules/@webassemblyjs/helper-module-context": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.8.5",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/helper-wasm-section": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-opt": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "@webassemblyjs/wast-printer": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-parser": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-code-frame": "1.8.5",
-        "@webassemblyjs/helper-fsm": "1.8.5",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.8.5",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "license": "Apache-2.0"
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/accepts": {
-      "version": "1.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "6.4.0",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/address": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-errors": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": ">=5.0.0"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/alphanum-sort": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause OR MIT",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.0.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "license": "MIT"
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "3.2.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "license": "Apache-2.0",
-      "bin": {
-        "ansi-html": "bin/ansi-html"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "license": "MIT"
-    },
-    "node_modules/anymatch": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      }
-    },
-    "node_modules/anymatch/node_modules/normalize-path": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "license": "ISC"
-    },
-    "node_modules/arch": {
-      "version": "2.1.1",
-      "license": "MIT"
-    },
-    "node_modules/archive-type": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/archive-type/node_modules/file-type": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/arr-diff": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-flatten": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-find-index": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/array-union": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-unique": {
-      "version": "0.3.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/asn1.js": {
-      "version": "4.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/assert": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "util": "0.10.3"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/assert/node_modules/inherits": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
-    "node_modules/assert/node_modules/util": {
-      "version": "0.10.3",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.1"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/async-each": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "node_modules/async-foreach": {
-      "version": "0.1.3",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/auto-bind": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "^16.8.12"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/autoprefixer": {
-      "version": "9.7.4",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.8.3",
-        "caniuse-lite": "^1.0.30001020",
-        "chalk": "^2.4.2",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.26",
-        "postcss-value-parser": "^4.0.2"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
-    "node_modules/autoprefixer/node_modules/postcss-value-parser": {
-      "version": "4.0.3",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.9.1",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
-    "node_modules/babel-helper-vue-jsx-merge-props": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-loader": {
-      "version": "8.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "find-cache-dir": "^2.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "webpack": ">=2"
-      }
-    },
-    "node_modules/babel-plugin-dynamic-import-node": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "object.assign": "^4.1.0"
-      }
-    },
-    "node_modules/bail": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/base": {
-      "version": "0.11.2",
-      "license": "MIT",
-      "dependencies": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.3.1",
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bin-build": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "decompress": "^4.0.0",
-        "download": "^6.2.2",
-        "execa": "^0.7.0",
-        "p-map-series": "^1.0.0",
-        "tempfile": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-check": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^0.7.0",
-        "executable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-version": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^1.0.0",
-        "find-versions": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version-check": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "bin-version": "^3.0.0",
-        "semver": "^5.6.0",
-        "semver-truncate": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version/node_modules/execa": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "bin-check": "^4.1.0",
-        "bin-version-check": "^4.0.0",
-        "download": "^7.1.0",
-        "import-lazy": "^3.1.0",
-        "os-filter-obj": "^2.0.0",
-        "pify": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/@sindresorhus/is": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/download": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "archive-type": "^4.0.0",
-        "caw": "^2.0.1",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.2.0",
-        "ext-name": "^5.0.0",
-        "file-type": "^8.1.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^8.3.1",
-        "make-dir": "^1.2.0",
-        "p-event": "^2.1.0",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/download/node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/file-type": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/got": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/got/node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/import-lazy": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/p-cancelable": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/p-event": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/p-timeout": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-wrapper/node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/block-stream": {
-      "version": "0.0.9",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "inherits": "~2.0.0"
-      },
-      "engines": {
-        "node": "0.4 || >=0.5.8"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "license": "MIT"
-    },
-    "node_modules/bn.js": {
-      "version": "4.11.8",
-      "license": "MIT"
-    },
-    "node_modules/body-parser": {
-      "version": "1.19.0",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "1.7.2",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/inherits": {
-      "version": "2.0.3",
-      "license": "ISC"
-    },
-    "node_modules/body-parser/node_modules/raw-body": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "node_modules/boxen": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/boxen/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "license": "MIT"
-    },
-    "node_modules/boxen/node_modules/string-width": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/browserify-aes": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/browserify-cipher": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "node_modules/browserify-des": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/browserify-rsa": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "node_modules/browserify-sign": {
-      "version": "4.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
-      }
-    },
-    "node_modules/browserify-zlib": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "~1.0.5"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.8.7",
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001027",
-        "electron-to-chromium": "^1.3.349",
-        "node-releases": "^1.1.49"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/browserslist"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "node_modules/builtin-status-codes": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/bytes": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "12.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/cacache/node_modules/y18n": {
-      "version": "4.0.0",
-      "license": "ISC"
-    },
-    "node_modules/cacache/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
-    "node_modules/cache-base": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cache-loader": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.0",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/sort-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-path": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001030",
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/case-sensitive-paths-webpack-plugin": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/caw": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-proxy": "^2.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "tunnel-agent": "^0.6.0",
-        "url-to-options": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ccount": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "2.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "^1.2.7"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC"
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/class-utils": {
-      "version": "0.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clipboard": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "node_modules/coa": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/collapse-white-space": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/collection-visit": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/color": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-convert/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/columnify": {
-      "version": "1.5.4",
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT"
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/config-chain": {
-      "version": "1.1.12",
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
-    "node_modules/configstore": {
-      "version": "4.0.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/connect-history-api-fallback": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/console-browserify": {
-      "version": "1.2.0"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "license": "ISC"
-    },
-    "node_modules/console-stream": {
-      "version": "0.1.1"
-    },
-    "node_modules/consolidate": {
-      "version": "0.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/constants-browserify": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/content-disposition": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-disposition/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/content-type": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "license": "MIT"
-    },
-    "node_modules/copy-concurrently": {
-      "version": "1.0.5",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
-      }
-    },
-    "node_modules/copy-descriptor": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.6.4",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat": {
-      "version": "3.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.8.3",
-        "semver": "7.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/create-ecdh": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/crypto-browserify": {
-      "version": "3.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/crypto-random-string": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-blank-pseudo": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "bin": {
-        "css-blank-pseudo": "cli.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/css-color-names": {
-      "version": "0.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/css-declaration-sorter": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
-      },
-      "engines": {
-        "node": ">4"
-      }
-    },
-    "node_modules/css-has-pseudo": {
-      "version": "0.10.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^5.0.0-rc.4"
-      },
-      "bin": {
-        "css-has-pseudo": "cli.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/css-has-pseudo/node_modules/cssesc": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-loader": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^5.2.0",
-        "icss-utils": "^4.1.0",
-        "loader-utils": "^1.2.3",
-        "normalize-path": "^3.0.0",
-        "postcss": "^7.0.14",
-        "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^2.0.6",
-        "postcss-modules-scope": "^2.1.0",
-        "postcss-modules-values": "^2.0.0",
-        "postcss-value-parser": "^3.3.0",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/css-prefers-color-scheme": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "bin": {
-        "css-prefers-color-scheme": "cli.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "1.2.0",
-      "license": "BSD-like",
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "node_modules/css-select-base-adapter": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "1.5.1",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "1.0.0-alpha.37",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.4",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/css-unit-converter": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/css-what": {
-      "version": "2.1.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cssdb": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "4.1.10",
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.7",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "4.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.1",
-        "postcss-colormin": "^4.0.3",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.2",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.11",
-        "postcss-merge-rules": "^4.0.3",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.2",
-        "postcss-minify-params": "^4.0.2",
-        "postcss-minify-selectors": "^4.0.2",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.2",
-        "postcss-normalize-positions": "^4.0.2",
-        "postcss-normalize-repeat-style": "^4.0.2",
-        "postcss-normalize-string": "^4.0.2",
-        "postcss-normalize-timing-functions": "^4.0.2",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.2",
-        "postcss-ordered-values": "^4.1.2",
-        "postcss-reduce-initial": "^4.0.3",
-        "postcss-reduce-transforms": "^4.0.2",
-        "postcss-svgo": "^4.0.2",
-        "postcss-unique-selectors": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-get-arguments": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-get-match": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-raw-cache": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-same-parent": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/csso": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "1.0.0-alpha.37"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/csstype": {
-      "version": "2.6.9",
-      "license": "MIT"
-    },
-    "node_modules/currently-unhandled": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "array-find-index": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cwebp-bin": {
-      "version": "5.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.1",
-        "logalot": "^2.1.0"
-      },
-      "bin": {
-        "cwebp": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cyclist": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/dateformat": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/decompress": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/bl": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/tar-stream": {
-      "version": "1.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/decompress-tarbz2": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "3.9.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/get-stream": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "object-keys": "^1.0.12"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/depd": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/des.js": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.0.4",
-      "license": "MIT"
-    },
-    "node_modules/detab": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.5.4"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/detect-indent": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detective": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.6.1",
-        "defined": "^1.0.0",
-        "minimist": "^1.1.1"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/didyoumean": {
-      "version": "1.2.1",
-      "license": "Apache"
-    },
-    "node_modules/diffie-hellman": {
-      "version": "5.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dom-converter": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domain-browser": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4",
-        "npm": ">=1.2"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "1.3.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/domhandler/node_modules/domelementtype": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domutils": {
-      "version": "1.7.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "6.2.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/download": {
-      "version": "6.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "caw": "^2.0.0",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.0.0",
-        "ext-name": "^5.0.0",
-        "file-type": "5.2.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^7.0.0",
-        "make-dir": "^1.0.0",
-        "p-event": "^1.0.0",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/duplexify": {
-      "version": "3.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.3.360",
-      "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.5.2",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "4.1.1",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/enhanced-resolve/node_modules/memory-fs": {
-      "version": "0.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/entities": {
-      "version": "2.0.0",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/envinfo": {
-      "version": "7.5.0",
-      "license": "MIT",
-      "bin": {
-        "envinfo": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/errno": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.1.1"
-      }
-    },
-    "node_modules/es-abstract": {
-      "version": "1.17.4",
-      "license": "MIT",
-      "dependencies": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "4.0.3",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.2.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "1.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "original": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/evp_bytestokey": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/exec-buffer": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/execa": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/execa/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/executable": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/executable/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/express": {
-      "version": "4.17.1",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-graphql": {
-      "version": "0.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^1.3.7",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.7.3",
-        "raw-body": "^2.4.1"
-      },
-      "engines": {
-        "node": ">= 8.x"
-      },
-      "peerDependencies": {
-        "graphql": "^14.4.1"
-      }
-    },
-    "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/ext-list": {
-      "version": "2.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.28.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ext-name": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
-    "node_modules/fast-glob": {
-      "version": "2.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.6.0",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.0"
-      }
-    },
-    "node_modules/faye-websocket": {
-      "version": "0.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
-    "node_modules/figgy-pudding": {
-      "version": "3.5.1",
-      "license": "ISC"
-    },
-    "node_modules/figures": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/file-loader": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/filename-reserved-regex": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/filenamify": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/make-dir": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/find-versions": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/flatten": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/flush-write-stream": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/for-in": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fragment-cache": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "map-cache": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "error-stack-parser": "^2.0.0",
-        "string-width": "^2.0.0"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/chalk": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/friendly-errors-webpack-plugin/node_modules/supports-color": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/fuse.js": {
-      "version": "3.4.6",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gaze": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globule": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/get-proxy": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "npm-conf": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/git-hooks-list": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT"
-    },
-    "node_modules/github-slugger": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.1.6",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.3.0",
-      "license": "BSD"
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globby": {
-      "version": "8.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^1.0.1",
-        "dir-glob": "2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globby/node_modules/slash": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/globule": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.12",
-        "minimatch": "~3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
-    },
-    "node_modules/got": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^3.2.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^1.1.1",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "url-parse-lax": "^1.0.0",
-        "url-to-options": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/got/node_modules/prepend-http": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/got/node_modules/url-parse-lax": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.3",
-      "license": "ISC"
-    },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/graphql": {
-      "version": "14.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 6.x"
-      }
-    },
-    "node_modules/graphql-compose": {
-      "version": "7.12.3",
-      "license": "MIT",
-      "dependencies": {
-        "graphql-type-json": "^0.3.1",
-        "object-path": "^0.11.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "graphql": "~0.13.0 || ^14.0.0"
-      }
-    },
-    "node_modules/graphql-playground-html": {
-      "version": "1.6.12",
-      "license": "SEE LICENSE IN LICENSE"
-    },
-    "node_modules/graphql-playground-middleware-express": {
-      "version": "1.7.12",
-      "license": "MIT",
-      "dependencies": {
-        "graphql-playground-html": "1.6.12"
-      },
-      "peerDependencies": {
-        "express": "^4.16.2"
-      }
-    },
-    "node_modules/graphql-type-json": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "graphql": ">=0.8.0"
-      }
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.11.0",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gridsome": {
-      "version": "0.7.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.0.0",
-        "@gridsome/cli": "^0.3.1",
-        "@hapi/joi": "^15.1.1",
-        "@sindresorhus/slugify": "^0.8.0",
-        "@vue/babel-preset-app": "^4.2.2",
-        "@vue/component-compiler-utils": "^2.5.2",
-        "address": "^1.1.0",
-        "auto-bind": "^2.0.0",
-        "autoprefixer": "^9.4.7",
-        "babel-loader": "8.0.5",
-        "cache-loader": "^2.0.1",
-        "camelcase": "^5.0.0",
-        "case-sensitive-paths-webpack-plugin": "^2.2.0",
-        "chalk": "^2.4.2",
-        "chokidar": "^2.1.0",
-        "color-string": "^1.5.3",
-        "columnify": "^1.5.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "css-loader": "^2.1.0",
-        "didyoumean": "^1.2.1",
-        "dotenv": "^6.2.0",
-        "eventemitter3": "^3.1.0",
-        "express": "^4.16.4",
-        "express-graphql": "^0.9.0",
-        "file-loader": "^3.0.1",
-        "friendly-errors-webpack-plugin": "^1.7.0",
-        "fs-extra": "^7.0.1",
-        "globby": "^9.0.0",
-        "graphql": "^14.4.2",
-        "graphql-compose": "^7.3.0",
-        "graphql-playground-middleware-express": "^1.7.12",
-        "hash-sum": "^1.0.2",
-        "hirestime": "^3.2.1",
-        "html-webpack-plugin": "^3.2.0",
-        "imagemin": "^6.1.0",
-        "imagemin-mozjpeg": "^8.0.0",
-        "imagemin-pngquant": "^7.0.0",
-        "imagemin-webp": "^5.0.0",
-        "invariant": "^2.2.4",
-        "is-relative": "^1.0.0",
-        "is-url": "^1.2.4",
-        "jest-worker": "24.0.0",
-        "json-loader": "^0.5.7",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.11",
-        "lokijs": "^1.5.6",
-        "lru-cache": "^5.1.1",
-        "md5-file": "^4.0.0",
-        "mime-types": "^2.1.21",
-        "mini-css-extract-plugin": "^0.5.0",
-        "mini-svg-data-uri": "^1.0.2",
-        "moment": "^2.24.0",
-        "optimize-css-assets-webpack-plugin": "^5.0.1",
-        "p-map": "^2.0.0",
-        "path-to-regexp": "^2.2.1",
-        "physical-cpu-count": "^2.0.0",
-        "portfinder": "^1.0.20",
-        "postcss-loader": "^3.0.0",
-        "probe-image-size": "^4.0.0",
-        "sharp": "^0.23.2",
-        "slash": "^2.0.0",
-        "sockjs": "^0.3.19",
-        "sockjs-client": "^1.3.0",
-        "stack-trace": "^0.0.10",
-        "tapable": "2.0.0-beta.5",
-        "url-loader": "^1.1.2",
-        "vue": "^2.6.10",
-        "vue-loader": "^15.7.1",
-        "vue-meta": "^2.2.2",
-        "vue-router": "^3.1.3",
-        "vue-server-renderer": "^2.6.10",
-        "vue-template-compiler": "^2.6.10",
-        "webpack": "^4.29.3",
-        "webpack-chain": "^5.2.0",
-        "webpack-dev-middleware": "^3.5.2",
-        "webpack-hot-middleware": "^2.24.3",
-        "webpack-merge": "^4.2.1",
-        "yaml-loader": "^0.5.0"
-      },
-      "bin": {
-        "gridsome": "bin/gridsome.js"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
-    "node_modules/gridsome-plugin-tailwindcss": {
-      "version": "2.2.36",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fullhuman/postcss-purgecss": "^2.0.6",
-        "postcss-import": "^12.0.1",
-        "postcss-preset-env": "^6.7.0",
-        "tailwindcss": "^1.2.0"
-      }
-    },
-    "node_modules/gridsome/node_modules/dir-glob": {
-      "version": "2.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/gridsome/node_modules/globby": {
-      "version": "9.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^1.0.2",
-        "dir-glob": "^2.2.2",
-        "fast-glob": "^2.2.6",
-        "glob": "^7.1.3",
-        "ignore": "^4.0.3",
-        "pify": "^4.0.1",
-        "slash": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gridsome/node_modules/ignore": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/gridsome/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/gridsome/node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gridsome/node_modules/tapable": {
-      "version": "2.0.0-beta.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gridsome/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/has-symbol-support-x": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-to-string-tag-x": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbol-support-x": "^1.4.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
-    "node_modules/has-value": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values/node_modules/kind-of": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-yarn": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/hash-base": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/hash-sum": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "2.2.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-sanitize": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "property-information": "^4.0.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/hast-util-to-html/node_modules/property-information": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/hast-util-to-html/node_modules/unist-util-is": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hastscript": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/hex-color-regex": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/hirestime": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.6",
-      "license": "ISC"
-    },
-    "node_modules/hsl-regex": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/hsla-regex": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/html-comment-regex": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "node_modules/html-entities": {
-      "version": "1.2.1",
-      "engines": [
-        "node >= 0.4.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/html-minifier": {
-      "version": "3.5.21",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.2.x",
-        "commander": "2.17.x",
-        "he": "1.2.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
-      },
-      "bin": {
-        "html-minifier": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/html-minifier/node_modules/commander": {
-      "version": "2.17.1",
-      "license": "MIT"
-    },
-    "node_modules/html-tags": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/html-to-text": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "he": "^1.0.0",
-        "htmlparser2": "^3.9.2",
-        "lodash": "^4.17.4",
-        "optimist": "^0.6.1"
-      },
-      "bin": {
-        "html-to-text": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/html-webpack-plugin": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
-        "toposort": "^1.0.0",
-        "util.promisify": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9"
-      },
-      "peerDependencies": {
-        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/big.js": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/json5": {
-      "version": "0.5.1",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/util.promisify": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domhandler": {
-      "version": "2.4.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "1.1.2",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/htmlparser2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "3.8.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-errors": {
-      "version": "1.7.3",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-parser-js": {
-      "version": "0.4.10",
-      "license": "MIT"
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/https-browserify": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "license": "ISC"
-    },
-    "node_modules/icss-utils": {
-      "version": "4.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/iferr": {
-      "version": "0.1.5",
-      "license": "MIT"
-    },
-    "node_modules/ignore": {
-      "version": "3.3.10",
-      "license": "MIT"
-    },
-    "node_modules/imagemin": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^10.7.0",
-        "globby": "^8.0.1",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^4.0.1",
-        "replace-ext": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-mozjpeg": {
-      "version": "8.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^1.0.0",
-        "is-jpg": "^2.0.0",
-        "mozjpeg": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-mozjpeg/node_modules/execa": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-mozjpeg/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-pngquant": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^1.0.0",
-        "is-png": "^1.0.0",
-        "is-stream": "^1.1.0",
-        "ow": "^0.8.0",
-        "pngquant-bin": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-pngquant/node_modules/execa": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-pngquant/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin-webp": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "cwebp-bin": "^5.0.0",
-        "exec-buffer": "^3.0.0",
-        "is-cwebp-readable": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin/node_modules/file-type": {
-      "version": "10.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/imagemin/node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/import-cwd": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "import-from": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-from": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-lazy": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/in-publish": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "in-install": "in-install.js",
-        "in-publish": "in-publish.js",
-        "not-in-install": "not-in-install.js",
-        "not-in-publish": "not-in-publish.js"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "repeating": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/indexes-of": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.5",
-      "license": "ISC",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/into-stream": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-absolute-url": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "license": "MIT"
-    },
-    "node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "license": "MIT"
-    },
-    "node_modules/is-callable": {
-      "version": "1.1.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^2.0.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
-    "node_modules/is-color-stop": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
-      }
-    },
-    "node_modules/is-cwebp-readable": {
-      "version": "2.0.1",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "file-type": "^4.3.0"
-      }
-    },
-    "node_modules/is-cwebp-readable/node_modules/file-type": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finite": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-installed-globally": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-jpg": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/is-natural-number": {
-      "version": "4.0.1",
-      "license": "MIT"
-    },
-    "node_modules/is-npm": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-object": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/is-path-inside": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "path-is-inside": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-png": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-relative": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-unc-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-resolvable": {
-      "version": "1.1.0",
-      "license": "ISC"
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-svg": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "html-comment-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/is-unc-path": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "unc-path-regex": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "license": "MIT"
-    },
-    "node_modules/is-utf8": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "node_modules/is-whitespace-character": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-word-character": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-yarn-global": {
-      "version": "0.3.0",
-      "license": "MIT"
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
-    },
-    "node_modules/isurl": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "license": "MIT"
-    },
-    "node_modules/javascript-stringify": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "node_modules/jest-worker": {
-      "version": "24.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "merge-stream": "^1.0.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/js-base64": {
-      "version": "2.5.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/json-loader": {
-      "version": "0.5.7",
-      "license": "MIT"
-    },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.2.3"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "license": "ISC"
-    },
-    "node_modules/json3": {
-      "version": "3.3.3",
-      "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/last-call-webpack-plugin": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.5",
-        "webpack-sources": "^1.1.0"
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "package-json": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/levenary": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "leven": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/load-json-file": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/load-json-file/node_modules/parse-json": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/load-json-file/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "2.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.15",
-      "license": "MIT"
-    },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.deburr": {
-      "version": "4.1.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "license": "MIT"
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.toarray": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
-    "node_modules/log-update": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/logalot": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/logalot/node_modules/figures": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lokijs": {
-      "version": "1.5.8",
-      "license": "MIT"
-    },
-    "node_modules/longest": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/loud-rejection": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lower-case": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lpad-align": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
-      },
-      "bin": {
-        "lpad-align": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/lru-cache/node_modules/yallist": {
-      "version": "2.1.2",
-      "license": "ISC"
-    },
-    "node_modules/make-dir": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mamacro": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
-    "node_modules/map-cache": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/map-visit": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/markdown-escapes": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/md5-file": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "bin": {
-        "md5-file": "cli.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/mdast-squeeze-paragraphs": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-remove": "^1.0.0"
-      }
-    },
-    "node_modules/mdast-util-definitions": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
-        "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.4",
-      "license": "CC0-1.0"
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/memory-fs": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/meow": {
-      "version": "3.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/merge-source-map": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/merge-stream": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "3.1.10",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/define-property": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/miller-rabin": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      },
-      "bin": {
-        "miller-rabin": "bin/miller-rabin"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.4.4",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.43.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.26",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.43.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "0.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.4.0"
-      }
-    },
-    "node_modules/mini-svg-data-uri": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/minimatch": {
-      "version": "3.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/minipass": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mississippi": {
-      "version": "3.0.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mixin-deep": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mixin-deep/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "0.0.8"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.24.0",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/move-concurrently": {
-      "version": "1.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
-      }
-    },
-    "node_modules/mozjpeg": {
-      "version": "6.0.1",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.0",
-        "logalot": "^2.1.0"
-      },
-      "bin": {
-        "mozjpeg": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
-    "node_modules/nan": {
-      "version": "2.14.0",
-      "license": "MIT"
-    },
-    "node_modules/nanomatch": {
-      "version": "1.2.13",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nanomatch/node_modules/define-property": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nanomatch/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nanomatch/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.1",
-      "license": "MIT"
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "license": "ISC"
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
-    "node_modules/no-case": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^1.1.1"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "2.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node_modules/node-emoji": {
-      "version": "1.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.toarray": "^4.4.0"
-      }
-    },
-    "node_modules/node-gyp": {
-      "version": "3.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-libs-browser": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^3.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.1",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
-        "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.11.0",
-        "vm-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/node-libs-browser/node_modules/punycode": {
-      "version": "1.4.1",
-      "license": "MIT"
-    },
-    "node_modules/node-releases": {
-      "version": "1.1.50",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.3.0"
-      }
-    },
-    "node_modules/node-releases/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-sass": {
-      "version": "4.13.1",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
-      },
-      "bin": {
-        "node-sass": "bin/node-sass"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/chalk": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/cross-spawn": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/node-sass/node_modules/supports-color": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/noop-logger": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
-    "node_modules/nopt": {
-      "version": "3.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/normalize.css": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-conf": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "1.0.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/num2fraction": {
-      "version": "1.2.2",
-      "license": "MIT"
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-path": {
-      "version": "0.11.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-visit": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.values": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/optimize-css-assets-webpack-plugin": {
-      "version": "5.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano": "^4.1.10",
-        "last-call-webpack-plugin": "^3.0.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "url-parse": "^1.4.3"
-      }
-    },
-    "node_modules/os-browserify": {
-      "version": "0.3.0",
-      "license": "MIT"
-    },
-    "node_modules/os-filter-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "arch": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osenv": {
-      "version": "0.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "node_modules/ow": {
-      "version": "0.8.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-event": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-map-series": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-reduce": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-pipe": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-reduce": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/package-json/node_modules/got": {
-      "version": "9.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/package-json/node_modules/http-cache-semantics": {
-      "version": "4.0.4",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/package-json/node_modules/keyv": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "node_modules/package-json/node_modules/normalize-url": {
-      "version": "4.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parallel-transform": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
-      }
-    },
-    "node_modules/param-case": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0"
-      }
-    },
-    "node_modules/parse-asn1": {
-      "version": "5.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/parse-entities": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/pascalcase": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/path-dirname": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-is-inside": {
-      "version": "1.0.2",
-      "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/path-key": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.6",
-      "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pbkdf2": {
-      "version": "3.0.17",
-      "license": "MIT",
-      "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/physical-cpu-count": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pngquant-bin": {
-      "version": "5.0.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.1",
-        "execa": "^0.10.0",
-        "logalot": "^2.0.0"
-      },
-      "bin": {
-        "pngquant": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pngquant-bin/node_modules/execa": {
-      "version": "0.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/portfinder": {
-      "version": "1.0.25",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
-      },
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/posix-character-classes": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "7.0.27",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/postcss"
-      }
-    },
-    "node_modules/postcss-attribute-case-insensitive": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^6.0.2"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "7.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.27",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "node_modules/postcss-calc/node_modules/postcss-value-parser": {
-      "version": "4.0.3",
-      "license": "MIT"
-    },
-    "node_modules/postcss-color-functional-notation": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-color-gray": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-color-hex-alpha": {
-      "version": "5.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.14",
-        "postcss-values-parser": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-color-mod-function": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-color-rebeccapurple": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-custom-media": {
-      "version": "7.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-custom-properties": {
-      "version": "8.0.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.17",
-        "postcss-values-parser": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-custom-selectors": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-custom-selectors/node_modules/cssesc": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-dir-pseudo-class": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-dir-pseudo-class/node_modules/cssesc": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-double-position-gradients": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-env-function": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-focus-visible": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-focus-within": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-font-variant": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-functions": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.2",
-        "object-assign": "^4.1.1",
-        "postcss": "^6.0.9",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/postcss": {
-      "version": "6.0.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-gap-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-image-set-function": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "12.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.1",
-        "postcss-value-parser": "^3.2.3",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-initial": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.template": "^4.5.0",
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1",
-        "postcss": "^7.0.18"
-      }
-    },
-    "node_modules/postcss-lab-function": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^5.0.0",
-        "import-cwd": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
-        "postcss-load-config": "^2.0.0",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-logical": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-media-minmax": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "4.0.11",
-      "license": "MIT",
-      "dependencies": {
-        "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/dot-prop": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/is-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/dot-prop": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/is-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^6.0.0",
-        "postcss-value-parser": "^3.3.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "2.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^7.0.6"
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.21",
-        "postcss-selector-parser": "^6.0.2"
-      }
-    },
-    "node_modules/postcss-nesting": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-normalize-charset": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-overflow-shorthand": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-page-break": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-place": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-preset-env": {
-      "version": "6.7.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "autoprefixer": "^9.6.1",
-        "browserslist": "^4.6.4",
-        "caniuse-lite": "^1.0.30000981",
-        "css-blank-pseudo": "^0.1.4",
-        "css-has-pseudo": "^0.10.0",
-        "css-prefers-color-scheme": "^3.1.1",
-        "cssdb": "^4.4.0",
-        "postcss": "^7.0.17",
-        "postcss-attribute-case-insensitive": "^4.0.1",
-        "postcss-color-functional-notation": "^2.0.1",
-        "postcss-color-gray": "^5.0.0",
-        "postcss-color-hex-alpha": "^5.0.3",
-        "postcss-color-mod-function": "^3.0.3",
-        "postcss-color-rebeccapurple": "^4.0.1",
-        "postcss-custom-media": "^7.0.8",
-        "postcss-custom-properties": "^8.0.11",
-        "postcss-custom-selectors": "^5.1.2",
-        "postcss-dir-pseudo-class": "^5.0.0",
-        "postcss-double-position-gradients": "^1.0.0",
-        "postcss-env-function": "^2.0.2",
-        "postcss-focus-visible": "^4.0.0",
-        "postcss-focus-within": "^3.0.0",
-        "postcss-font-variant": "^4.0.0",
-        "postcss-gap-properties": "^2.0.0",
-        "postcss-image-set-function": "^3.0.1",
-        "postcss-initial": "^3.0.0",
-        "postcss-lab-function": "^2.0.1",
-        "postcss-logical": "^3.0.0",
-        "postcss-media-minmax": "^4.0.0",
-        "postcss-nesting": "^7.0.0",
-        "postcss-overflow-shorthand": "^2.0.0",
-        "postcss-page-break": "^2.0.0",
-        "postcss-place": "^4.0.1",
-        "postcss-pseudo-class-any-link": "^6.0.0",
-        "postcss-replace-overflow-wrap": "^3.0.0",
-        "postcss-selector-matches": "^4.0.0",
-        "postcss-selector-not": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-pseudo-class-any-link": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-pseudo-class-any-link/node_modules/cssesc": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-replace-overflow-wrap": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-selector-matches": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-selector-not": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-svg": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "license": "MIT"
-    },
-    "node_modules/postcss-values-parser": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.14.4"
-      }
-    },
-    "node_modules/postcss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "5.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "1.16.3",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pretty-error": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
-      }
-    },
-    "node_modules/pretty-hrtime": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/prism-themes": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/prismjs": {
-      "version": "1.19.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "clipboard": "^2.0.0"
-      }
-    },
-    "node_modules/private": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/probe-image-size": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.3.0",
-        "deepmerge": "^4.0.0",
-        "inherits": "^2.0.3",
-        "next-tick": "^1.0.0",
-        "request": "^2.83.0",
-        "stream-parser": "~0.3.1"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
-    "node_modules/property-information": {
-      "version": "5.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "license": "ISC"
-    },
-    "node_modules/proxy-addr": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
-    "node_modules/psl": {
-      "version": "1.7.0",
-      "license": "MIT"
-    },
-    "node_modules/public-encrypt": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/pumpify": {
-      "version": "1.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      }
-    },
-    "node_modules/pumpify/node_modules/pump": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/purgecss": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^4.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.27",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "bin": {
-        "purgecss": "bin/purgecss"
-      }
-    },
-    "node_modules/purgecss/node_modules/commander": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.7.0",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/querystring-es3": {
-      "version": "0.2.1",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/querystringify": {
-      "version": "2.1.1",
-      "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/randomfill": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.3",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
-    "node_modules/read-cache/node_modules/pify": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/path-type": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/readable-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/redent": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reduce-css-calc": {
-      "version": "2.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/regenerate": {
-      "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/regenerate-unicode-properties": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.3",
-      "license": "MIT"
-    },
-    "node_modules/regenerator-transform": {
-      "version": "0.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "private": "^0.1.6"
-      }
-    },
-    "node_modules/regex-not": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regex-not/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regex-not/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regexpu-core": {
-      "version": "4.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.1.0",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/registry-auth-token": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.5.1",
-      "license": "MIT"
-    },
-    "node_modules/regjsparser": {
-      "version": "0.6.3",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "jsesc": "~0.5.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
-      }
-    },
-    "node_modules/regjsparser/node_modules/jsesc": {
-      "version": "0.5.0",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/remark-autolink-headings": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "unist-util-visit": "^1.0.1"
-      }
-    },
-    "node_modules/remark-external-links": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-absolute-url": "^2.1.0",
-        "mdast-util-definitions": "^1.2.3",
-        "space-separated-tokens": "^1.1.2",
-        "unist-util-visit": "^1.4.0"
-      }
-    },
-    "node_modules/remark-fix-guillemets": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/remark-fix-guillemets/node_modules/unist-util-is": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-fix-guillemets/node_modules/unist-util-visit": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-fix-guillemets/node_modules/unist-util-visit-parents": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-html": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hast-util-sanitize": "^1.0.0",
-        "hast-util-to-html": "^4.0.0",
-        "mdast-util-to-hast": "^3.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/remark-slug": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "github-slugger": "^1.0.0",
-        "mdast-util-to-string": "^1.0.0",
-        "unist-util-visit": "^1.0.0"
-      }
-    },
-    "node_modules/remark-squeeze-paragraphs": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdast-squeeze-paragraphs": "^3.0.0"
-      }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "license": "ISC"
-    },
-    "node_modules/renderkid": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^1.1.0",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "^0.4.0"
-      }
-    },
-    "node_modules/repeat-element": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/repeating": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-finite": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/replace-ext": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-cwd": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "node_modules/responselike": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rgb-regex": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/rgba-regex": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.1.9",
-      "license": "MIT"
-    },
-    "node_modules/run-queue": {
-      "version": "1.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.0",
-      "license": "MIT"
-    },
-    "node_modules/safe-regex": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.1.10"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
-    "node_modules/sanitize-html": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "htmlparser2": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.1",
-        "postcss": "^7.0.27",
-        "srcset": "^2.0.1",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domelementtype": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^0.2.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/sass-graph": {
-      "version": "2.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
-      }
-    },
-    "node_modules/sass-loader": {
-      "version": "8.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0",
-        "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "2.6.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/sass-loader/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "license": "ISC"
-    },
-    "node_modules/schema-utils": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/scss-tokenizer": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
-      }
-    },
-    "node_modules/scss-tokenizer/node_modules/source-map": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/seek-bzip": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "~2.8.1"
-      },
-      "bin": {
-        "seek-bunzip": "bin/seek-bunzip",
-        "seek-table": "bin/seek-bzip-table"
-      }
-    },
-    "node_modules/seek-bzip/node_modules/commander": {
-      "version": "2.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semver-truncate": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/send": {
-      "version": "0.17.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
-        "mime": "1.6.0",
-        "ms": "2.1.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.1",
-      "license": "MIT"
-    },
-    "node_modules/serialize-javascript": {
-      "version": "2.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/serve-static": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      }
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sharp": {
-      "version": "0.23.4",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^3.1.2",
-        "detect-libc": "^1.0.3",
-        "nan": "^2.14.0",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^5.3.3",
-        "semver": "^6.3.0",
-        "simple-get": "^3.1.0",
-        "tar": "^5.0.5",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/sharp/node_modules/tar": {
-      "version": "5.0.5",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^1.1.3",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.0",
-        "mkdirp": "^0.5.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.2",
-      "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-get/node_modules/decompress-response": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/simple-get/node_modules/mimic-response": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/sitemap": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.10",
-        "url-join": "^4.0.0",
-        "xmlbuilder": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=4.0.0"
-      }
-    },
-    "node_modules/slash": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/snapdragon": {
-      "version": "0.8.2",
-      "license": "MIT",
-      "dependencies": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sockjs": {
-      "version": "0.3.19",
-      "license": "MIT",
-      "dependencies": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/sockjs-client": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.5",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "~0.11.1",
-        "inherits": "^2.0.3",
-        "json3": "^3.3.2",
-        "url-parse": "^1.4.3"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/faye-websocket": {
-      "version": "0.11.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/sort-keys": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-keys-length": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "sort-keys": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object-keys": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/sort-package-json": {
-      "version": "1.40.0",
-      "license": "MIT",
-      "dependencies": {
-        "detect-indent": "^6.0.0",
-        "detect-newline": "3.1.0",
-        "git-hooks-list": "1.0.2",
-        "globby": "10.0.1",
-        "is-plain-obj": "2.1.0",
-        "sort-object-keys": "^1.1.3"
-      },
-      "bin": {
-        "sort-package-json": "cli.js"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/array-union": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/braces": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/fast-glob": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/fill-range": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/glob-parent": {
-      "version": "5.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/globby": {
-      "version": "10.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/ignore": {
-      "version": "5.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/is-number": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/micromatch": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/path-type": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/slash": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.16",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/spdx-correct": {
-      "version": "3.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.2.0",
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.5",
-      "license": "CC0-1.0"
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/squeak": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/squeak/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/squeak/node_modules/chalk": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/squeak/node_modules/supports-color": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/srcset": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "6.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "license": "MIT"
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/stackframe": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/state-toggle": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/static-extend": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/stdout-stream": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/stream-browserify": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-each": {
-      "version": "1.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/stream-http": {
-      "version": "2.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/stream-parser": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2"
-      }
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string.prototype.trimleft": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimright": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-dirs": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-natural-number": "^4.0.1"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-stdin": "^4.0.1"
-      },
-      "bin": {
-        "strip-indent": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-outer": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stylehacks": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/stylehacks/node_modules/dot-prop": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylehacks/node_modules/is-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylehacks/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svg-tags": {
-      "version": "1.0.0"
-    },
-    "node_modules/svgo": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "coa": "^2.0.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.37",
-        "csso": "^4.0.2",
-        "js-yaml": "^3.13.1",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.1.0",
-        "sax": "~1.2.4",
-        "stable": "^0.1.8",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "2.1.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^3.2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
-      }
-    },
-    "node_modules/svgo/node_modules/css-what": {
-      "version": "3.2.1",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "autoprefixer": "^9.4.5",
-        "bytes": "^3.0.0",
-        "chalk": "^3.0.0",
-        "detective": "^5.2.0",
-        "fs-extra": "^8.0.0",
-        "lodash": "^4.17.15",
-        "node-emoji": "^1.8.1",
-        "normalize.css": "^8.0.1",
-        "postcss": "^7.0.11",
-        "postcss-functions": "^3.0.0",
-        "postcss-js": "^2.0.0",
-        "postcss-nested": "^4.1.1",
-        "postcss-selector-parser": "^6.0.0",
-        "pretty-hrtime": "^1.0.3",
-        "reduce-css-calc": "^2.1.6",
-        "resolve": "^1.14.2"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/ansi-styles": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/supports-color": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^3.0.0",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/temp-dir": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tempfile": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/term-size": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/terser": {
-      "version": "4.6.4",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/timed-out": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/timers-browserify": {
-      "version": "2.0.11",
-      "license": "MIT",
-      "dependencies": {
-        "setimmediate": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "license": "MIT"
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/to-arraybuffer": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/to-buffer": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/to-object-path": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-object-path/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/to-regex": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex/node_modules/define-property": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/toidentifier": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/toposort": {
-      "version": "1.0.7",
-      "license": "MIT"
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/trim": {
-      "version": "0.0.1",
-      "dev": true
-    },
-    "node_modules/trim-lines": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/trim-repeated": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/trim-trailing-lines": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trough": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/true-case-path": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "glob": "^7.1.2"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "1.11.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/tty-browserify": {
-      "version": "0.0.0",
-      "license": "MIT"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
-    },
-    "node_modules/type-fest": {
-      "version": "0.3.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "license": "MIT"
-    },
-    "node_modules/uglify-js": {
-      "version": "3.4.10",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "~2.19.0",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uglify-js/node_modules/commander": {
-      "version": "2.19.0",
-      "license": "MIT"
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
-    "node_modules/unbzip2-stream/node_modules/buffer": {
-      "version": "5.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/unc-path-regex": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unherit": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unified": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
-      }
-    },
-    "node_modules/unified/node_modules/is-buffer": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unified/node_modules/vfile": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
-      }
-    },
-    "node_modules/unified/node_modules/vfile-message": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-stringify-position": "^1.1.1"
-      }
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/uniq": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    "node_modules/uniqs": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unist-builder": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.0"
-      }
-    },
-    "node_modules/unist-util-generated": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unist-util-position": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/unquote": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/unset-value": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-values": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/upath": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
-    "node_modules/update-notifier": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boxen": "^3.0.0",
-        "chalk": "^2.0.1",
-        "configstore": "^4.0.0",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^3.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/upper-case": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/uri-js": {
-      "version": "4.2.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "license": "MIT"
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/url-loader": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "mime": "^2.0.3",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.4.7",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/url-to-options": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "license": "MIT"
-    },
-    "node_modules/use": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.11.1",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/util.promisify": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.2",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "license": "ISC"
-    },
-    "node_modules/utila": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/vendors": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/extsprintf": {
-      "version": "1.4.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/vfile": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message/node_modules/unist-util-stringify-position": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile/node_modules/is-buffer": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vfile/node_modules/unist-util-stringify-position": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vm-browserify": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "node_modules/vue": {
-      "version": "2.6.11",
-      "license": "MIT"
-    },
-    "node_modules/vue-analytics": {
-      "version": "5.22.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vue-feather-icons": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-vue-jsx-merge-props": "^2.0.2"
-      }
-    },
-    "node_modules/vue-hot-reload-api": {
-      "version": "2.3.4",
-      "license": "MIT"
-    },
-    "node_modules/vue-loader": {
-      "version": "15.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
-      },
-      "peerDependencies": {
-        "css-loader": "*",
-        "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "cache-loader": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vue-loader/node_modules/@vue/component-compiler-utils": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "consolidate": "^0.15.1",
-        "hash-sum": "^1.0.2",
-        "lru-cache": "^4.1.2",
-        "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.14",
-        "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
-        "source-map": "~0.6.1",
-        "vue-template-es2015-compiler": "^1.9.0"
-      }
-    },
-    "node_modules/vue-loader/node_modules/prettier": {
-      "version": "1.19.1",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vue-meta": {
-      "version": "2.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2"
-      }
-    },
-    "node_modules/vue-router": {
-      "version": "3.1.5",
-      "license": "MIT"
-    },
-    "node_modules/vue-server-renderer": {
-      "version": "2.6.11",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "hash-sum": "^1.0.2",
-        "he": "^1.1.0",
-        "lodash.template": "^4.5.0",
-        "lodash.uniq": "^4.5.0",
-        "resolve": "^1.2.0",
-        "serialize-javascript": "^2.1.2",
-        "source-map": "0.5.6"
-      }
-    },
-    "node_modules/vue-server-renderer/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vue-server-renderer/node_modules/chalk": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vue-server-renderer/node_modules/source-map": {
-      "version": "0.5.6",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vue-server-renderer/node_modules/supports-color": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/vue-style-loader": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.0.2"
-      }
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.6.11",
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.1.0"
-      }
-    },
-    "node_modules/vue-template-es2015-compiler": {
-      "version": "1.9.1",
-      "license": "MIT"
-    },
-    "node_modules/watchpack": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/webpack": {
-      "version": "4.41.6",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.0",
-        "webpack-sources": "^1.4.1"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/webpack-chain": {
-      "version": "5.2.4",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "deepmerge": "^1.5.2",
-        "javascript-stringify": "^2.0.0"
-      }
-    },
-    "node_modules/webpack-chain/node_modules/deepmerge": {
-      "version": "1.5.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-middleware": {
-      "version": "3.7.2",
-      "license": "MIT",
-      "dependencies": {
-        "memory-fs": "^0.4.1",
-        "mime": "^2.4.4",
-        "mkdirp": "^0.5.1",
-        "range-parser": "^1.2.1",
-        "webpack-log": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/webpack-hot-middleware": {
-      "version": "2.25.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
-        "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "node_modules/webpack-log": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/webpack-merge": {
-      "version": "4.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-parser-js": ">=0.4.0 <0.4.11",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/which-module": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/widest-line": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/worker-farm": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "errno": "~0.1.7"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/x-is-string": {
-      "version": "0.1.0",
-      "dev": true
-    },
-    "node_modules/xdg-basedir": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "10.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
-    },
-    "node_modules/yaml-loader": {
-      "version": "0.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.5.2"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^5.0.0"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^3.0.0"
-      }
-    },
-    "node_modules/yargs-parser/node_modules/camelcase": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/camelcase": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    }
-  },
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/compat-data": {
       "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+      "integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
       "requires": {
         "browserslist": "^4.8.5",
         "invariant": "^2.2.4",
@@ -13521,6 +23,8 @@
     },
     "@babel/core": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.8.4",
@@ -13541,23 +45,31 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "json5": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "source-map": {
-          "version": "0.5.7"
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/generator": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "requires": {
         "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
@@ -13566,18 +78,24 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7"
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+      "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+      "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.8.3",
         "@babel/types": "^7.8.3"
@@ -13585,6 +103,8 @@
     },
     "@babel/helper-call-delegate": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+      "integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.8.3",
         "@babel/traverse": "^7.8.3",
@@ -13593,6 +113,8 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+      "integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
       "requires": {
         "@babel/compat-data": "^7.8.4",
         "browserslist": "^4.8.5",
@@ -13603,6 +125,8 @@
     },
     "@babel/helper-create-class-features-plugin": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
+      "integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-member-expression-to-functions": "^7.8.3",
@@ -13614,6 +138,8 @@
     },
     "@babel/helper-create-regexp-features-plugin": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+      "integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
       "requires": {
         "@babel/helper-regex": "^7.8.3",
         "regexpu-core": "^4.6.0"
@@ -13621,6 +147,8 @@
     },
     "@babel/helper-define-map": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+      "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
@@ -13629,6 +157,8 @@
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+      "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
       "requires": {
         "@babel/traverse": "^7.8.3",
         "@babel/types": "^7.8.3"
@@ -13636,6 +166,8 @@
     },
     "@babel/helper-function-name": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -13644,30 +176,40 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-hoist-variables": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+      "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-module-imports": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-module-transforms": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+      "integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
@@ -13679,21 +221,29 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.8.3"
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
     },
     "@babel/helper-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+      "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "requires": {
         "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-wrap-function": "^7.8.3",
@@ -13704,6 +254,8 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+      "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
@@ -13713,6 +265,8 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
       "requires": {
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3"
@@ -13720,12 +274,16 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+      "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -13735,6 +293,8 @@
     },
     "@babel/helpers": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "requires": {
         "@babel/template": "^7.8.3",
         "@babel/traverse": "^7.8.4",
@@ -13743,6 +303,8 @@
     },
     "@babel/highlight": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -13750,10 +312,14 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.4"
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+      "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-remap-async-to-generator": "^7.8.3",
@@ -13762,6 +328,8 @@
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+      "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -13769,6 +337,8 @@
     },
     "@babel/plugin-proposal-decorators": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
+      "integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -13777,6 +347,8 @@
     },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
@@ -13784,6 +356,8 @@
     },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+      "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-json-strings": "^7.8.0"
@@ -13791,6 +365,8 @@
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
@@ -13798,6 +374,8 @@
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
@@ -13805,6 +383,8 @@
     },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
@@ -13812,6 +392,8 @@
     },
     "@babel/plugin-proposal-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
@@ -13819,6 +401,8 @@
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+      "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -13826,72 +410,96 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-decorators": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
+      "integrity": "sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+      "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-top-level-await": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+      "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+      "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -13900,12 +508,16 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+      "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+      "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "lodash": "^4.17.13"
@@ -13913,6 +525,8 @@
     },
     "@babel/plugin-transform-classes": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+      "integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-define-map": "^7.8.3",
@@ -13926,18 +540,24 @@
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+      "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-destructuring": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+      "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+      "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -13945,12 +565,16 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+      "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+      "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -13958,12 +582,16 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+      "integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+      "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -13971,18 +599,24 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+      "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+      "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+      "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
       "requires": {
         "@babel/helper-module-transforms": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -13991,6 +625,8 @@
     },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+      "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
       "requires": {
         "@babel/helper-module-transforms": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -14000,6 +636,8 @@
     },
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+      "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.8.3",
         "@babel/helper-module-transforms": "^7.8.3",
@@ -14009,6 +647,8 @@
     },
     "@babel/plugin-transform-modules-umd": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+      "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
       "requires": {
         "@babel/helper-module-transforms": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -14016,18 +656,24 @@
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+      "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3"
       }
     },
     "@babel/plugin-transform-new-target": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+      "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-object-super": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+      "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-replace-supers": "^7.8.3"
@@ -14035,6 +681,8 @@
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+      "integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
       "requires": {
         "@babel/helper-call-delegate": "^7.8.3",
         "@babel/helper-get-function-arity": "^7.8.3",
@@ -14043,24 +691,32 @@
     },
     "@babel/plugin-transform-property-literals": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+      "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+      "integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
       "requires": {
         "regenerator-transform": "^0.14.0"
       }
     },
     "@babel/plugin-transform-reserved-words": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+      "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-runtime": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -14070,18 +726,24 @@
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+      "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+      "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+      "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-regex": "^7.8.3"
@@ -14089,6 +751,8 @@
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+      "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -14096,12 +760,16 @@
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+      "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+      "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -14109,6 +777,8 @@
     },
     "@babel/preset-env": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+      "integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
       "requires": {
         "@babel/compat-data": "^7.8.4",
         "@babel/helper-compilation-targets": "^7.8.4",
@@ -14171,12 +841,16 @@
     },
     "@babel/runtime": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.8.3",
@@ -14185,6 +859,8 @@
     },
     "@babel/traverse": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.8.4",
@@ -14199,6 +875,8 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -14207,6 +885,8 @@
     },
     "@babel/types": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
@@ -14215,10 +895,14 @@
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+      "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
       "dev": true
     },
     "@fullhuman/postcss-purgecss": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.0.tgz",
+      "integrity": "sha512-zmV+cK8pAo/suKMQk1fKzDdols5ltOy86Hk51qwkiJJt4olm3t1MaUrm4U4MlA9fiYeRpLqsNop2xNoEm8DV+w==",
       "dev": true,
       "requires": {
         "postcss": "7.0.27",
@@ -14227,6 +911,8 @@
     },
     "@gridsome/cli": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gridsome/cli/-/cli-0.3.1.tgz",
+      "integrity": "sha512-DBzX0yWAE98kn1oZ69oT5dPqUNd9Isr+2/YFU/XP7e/+5OHEYsXdVlFrLgHkEwAsJvtfbkm5s5654mQ7UoK+rg==",
       "requires": {
         "@hjvedvik/tasks": "^0.0.8",
         "chalk": "^2.4.1",
@@ -14244,6 +930,8 @@
       "dependencies": {
         "execa": {
           "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
@@ -14256,6 +944,8 @@
         },
         "fs-extra": {
           "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -14266,6 +956,8 @@
     },
     "@gridsome/plugin-google-analytics": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@gridsome/plugin-google-analytics/-/plugin-google-analytics-0.1.0.tgz",
+      "integrity": "sha512-IUuIj1z0BMtNa4NPRyBP3rYGyww+RWypsHTJ7WDdIj/BuH1x7BR9cDn7kskfG5azUi1LV0lJX329Te077oG07A==",
       "dev": true,
       "requires": {
         "vue-analytics": "^5.16.1"
@@ -14273,6 +965,8 @@
     },
     "@gridsome/plugin-sitemap": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@gridsome/plugin-sitemap/-/plugin-sitemap-0.2.3.tgz",
+      "integrity": "sha512-7XtE8SSZrYmM7/lf91giF44rHSBKfaMNr+QcZ/Ctq9WIC7ga3YWiA7COshX6sBJK8okhP6djx82QbKnX8c8IYQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
@@ -14282,6 +976,8 @@
     },
     "@gridsome/remark-prismjs": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@gridsome/remark-prismjs/-/remark-prismjs-0.3.0.tgz",
+      "integrity": "sha512-kwVcz2K7wunzgHnFKeGr+bvNfN1Q1PbOpYwEWXG+yn+SokXfPKjsu4KW0FBKOWD8eTwMlkyE7aqPVTxnD6BOMw==",
       "dev": true,
       "requires": {
         "escape-html": "^1.0.3",
@@ -14294,6 +990,8 @@
       "dependencies": {
         "hast-util-to-html": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-6.1.0.tgz",
+          "integrity": "sha512-IlC+LG2HGv0Y8js3wqdhg9O2sO4iVpRDbHOPwXd7qgeagpGsnY49i8yyazwqS35RA35WCzrBQE/n0M6GG/ewxA==",
           "dev": true,
           "requires": {
             "ccount": "^1.0.0",
@@ -14310,6 +1008,8 @@
         },
         "stringify-entities": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
+          "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
           "dev": true,
           "requires": {
             "character-entities-html4": "^1.0.0",
@@ -14323,6 +1023,8 @@
     },
     "@gridsome/source-filesystem": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@gridsome/source-filesystem/-/source-filesystem-0.6.2.tgz",
+      "integrity": "sha512-K1pyXwFYIlABaHq3wqOPyYt4ARzLZuUQ+UZKjDSBT9I0T0qpCbwir5kJMQkR7qY4ONflUrv8fgG6DNSrc1uzbA==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
@@ -14335,6 +1037,8 @@
     },
     "@gridsome/transformer-remark": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@gridsome/transformer-remark/-/transformer-remark-0.5.0.tgz",
+      "integrity": "sha512-uTVkc4BbQIuo9KzA4nchHhADHznLLyMXCTwSZ238xG2f5QWcsLtQRuPnKBID0nFx+9U6nvRE5YoC4FF2DBDU2A==",
       "dev": true,
       "requires": {
         "gray-matter": "^4.0.2",
@@ -14358,6 +1062,8 @@
       "dependencies": {
         "lru-cache": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -14365,21 +1071,31 @@
         },
         "yallist": {
           "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
     },
     "@hapi/address": {
-      "version": "2.1.4"
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
     },
     "@hapi/bourne": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.1"
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "requires": {
         "@hapi/address": "2.x.x",
         "@hapi/bourne": "1.x.x",
@@ -14389,12 +1105,16 @@
     },
     "@hapi/topo": {
       "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
         "@hapi/hoek": "^8.3.0"
       }
     },
     "@hjvedvik/tasks": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@hjvedvik/tasks/-/tasks-0.0.8.tgz",
+      "integrity": "sha512-vR+AIKFtQl6UG0npTdIMVb5vfo+Kz+xgygW4kCUJ0f5ekr8WifXM4A36wnbf3xVvny8mRdMPXk/n5oT0lMapVg==",
       "requires": {
         "chalk": "^2.4.1",
         "dateformat": "^3.0.3",
@@ -14405,12 +1125,16 @@
       },
       "dependencies": {
         "p-map": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
         }
       }
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
@@ -14418,26 +1142,36 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
     },
     "@sindresorhus/is": {
-      "version": "0.14.0"
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sindresorhus/slugify": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-0.8.0.tgz",
+      "integrity": "sha512-Y+C3aG0JHmi4nCfixHgq0iAtqWCjMCliWghf6fXbemRKSGzpcrHdYxGZGDt8MeFg+gH7ounfMbz6WogqKCWvDg==",
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "lodash.deburr": "^4.1.0"
@@ -14445,19 +1179,27 @@
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
     },
     "@types/color-name": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/events": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -14465,19 +1207,29 @@
       }
     },
     "@types/minimatch": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.7.6"
+      "version": "13.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.6.tgz",
+      "integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA=="
     },
     "@types/prop-types": {
-      "version": "15.7.3"
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
       "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -14485,10 +1237,14 @@
     },
     "@types/unist": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
     "@types/vfile": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -14498,16 +1254,22 @@
     },
     "@types/vfile-message": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
+      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
       "dev": true,
       "requires": {
         "vfile-message": "*"
       }
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
+      "integrity": "sha512-6tyf5Cqm4m6v7buITuwS+jHzPlIPxbFzEhXR5JGZpbrvOcp1hiQKckd305/3C7C36wFekNTQSxAtgeM0j0yoUw=="
     },
     "@vue/babel-plugin-transform-vue-jsx": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-1.1.2.tgz",
+      "integrity": "sha512-YfdaoSMvD1nj7+DsrwfTvTnhDXI7bsuh+Y5qWwvQXlD24uLgnsoww3qbiZvWf/EoviZMrvqkqN4CBw0W3BWUTQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0",
@@ -14519,6 +1281,8 @@
     },
     "@vue/babel-preset-app": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.2.2.tgz",
+      "integrity": "sha512-QGgL+iR+ZdNO9xcFJqYjg938bwjArgIyNOFfM0m+dNSOt7wWVrlFA2v0C6aVN1sJ+IEjdurEolBTZ7hXp6Fbsg==",
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/helper-compilation-targets": "^7.8.4",
@@ -14538,6 +1302,8 @@
     },
     "@vue/babel-preset-jsx": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-jsx/-/babel-preset-jsx-1.1.2.tgz",
+      "integrity": "sha512-zDpVnFpeC9YXmvGIDSsKNdL7qCG2rA3gjywLYHPCKDT10erjxF4U+6ay9X6TW5fl4GsDlJp9bVfAVQAAVzxxvQ==",
       "requires": {
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
         "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
@@ -14549,18 +1315,24 @@
     },
     "@vue/babel-sugar-functional-vue": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-functional-vue/-/babel-sugar-functional-vue-1.1.2.tgz",
+      "integrity": "sha512-YhmdJQSVEFF5ETJXzrMpj0nkCXEa39TvVxJTuVjzvP2rgKhdMmQzlJuMv/HpadhZaRVMCCF3AEjjJcK5q/cYzQ==",
       "requires": {
         "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@vue/babel-sugar-inject-h": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-inject-h/-/babel-sugar-inject-h-1.1.2.tgz",
+      "integrity": "sha512-VRSENdTvD5htpnVp7i7DNuChR5rVMcORdXjvv5HVvpdKHzDZAYiLSD+GhnhxLm3/dMuk8pSzV+k28ECkiN5m8w==",
       "requires": {
         "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@vue/babel-sugar-v-model": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-model/-/babel-sugar-v-model-1.1.2.tgz",
+      "integrity": "sha512-vLXPvNq8vDtt0u9LqFdpGM9W9IWDmCmCyJXuozlq4F4UYVleXJ2Fa+3JsnTZNJcG+pLjjfnEGHci2339Kj5sGg==",
       "requires": {
         "@babel/plugin-syntax-jsx": "^7.2.0",
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
@@ -14572,6 +1344,8 @@
     },
     "@vue/babel-sugar-v-on": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-on/-/babel-sugar-v-on-1.1.2.tgz",
+      "integrity": "sha512-T8ZCwC8Jp2uRtcZ88YwZtZXe7eQrJcfRq0uTFy6ShbwYJyz5qWskRFoVsdTi9o0WEhmQXxhQUewodOSCUPVmsQ==",
       "requires": {
         "@babel/plugin-syntax-jsx": "^7.2.0",
         "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
@@ -14580,6 +1354,8 @@
     },
     "@vue/component-compiler-utils": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
       "requires": {
         "consolidate": "^0.15.1",
         "hash-sum": "^1.0.2",
@@ -14593,10 +1369,14 @@
       },
       "dependencies": {
         "cssesc": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
             "indexes-of": "^1.0.1",
@@ -14607,6 +1387,8 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
       "requires": {
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
@@ -14614,35 +1396,51 @@
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
       "requires": {
         "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-buffer": "1.8.5",
@@ -14652,21 +1450,29 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-buffer": "1.8.5",
@@ -14680,6 +1486,8 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
@@ -14690,6 +1498,8 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-buffer": "1.8.5",
@@ -14699,6 +1509,8 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-api-error": "1.8.5",
@@ -14710,6 +1522,8 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/floating-point-hex-parser": "1.8.5",
@@ -14721,6 +1535,8 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/wast-parser": "1.8.5",
@@ -14728,27 +1544,39 @@
       }
     },
     "@xtuc/ieee754": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
     },
     "@xtuc/long": {
-      "version": "4.2.2"
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "abbrev": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
     "acorn": {
-      "version": "6.4.0"
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
     },
     "acorn-node": {
       "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
       "dev": true,
       "requires": {
         "acorn": "^7.0.0",
@@ -14758,16 +1586,22 @@
       "dependencies": {
         "acorn": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
           "dev": true
         }
       }
     },
     "acorn-walk": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
       "dev": true
     },
     "address": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+      "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -14782,35 +1616,47 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "requires": {}
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "alphanum-sort": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amdefine": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-align": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "requires": {
         "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "emoji-regex": {
-          "version": "7.0.3"
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "string-width": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -14819,6 +1665,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -14826,28 +1674,42 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.4"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
     "ansi-escapes": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-html": {
-      "version": "0.0.7"
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
       }
     },
     "any-promise": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -14855,6 +1717,8 @@
       "dependencies": {
         "normalize-path": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -14862,24 +1726,34 @@
       }
     },
     "aproba": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "arch": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
     },
     "archive-type": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+      "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
       "requires": {
         "file-type": "^4.2.0"
       },
       "dependencies": {
         "file-type": {
-          "version": "4.4.0"
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
         }
       }
     },
     "are-we-there-yet": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -14887,48 +1761,72 @@
     },
     "argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-find-index": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
         "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "arrify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
       "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -14937,16 +1835,22 @@
     },
     "assert": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
         "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
           "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
           }
@@ -14954,38 +1858,56 @@
       }
     },
     "assert-plus": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
         "lodash": "^4.17.14"
       }
     },
     "async-each": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
     "async-foreach": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "auto-bind": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-2.1.1.tgz",
+      "integrity": "sha512-NUwV1i9D3vxxY1KnfZgSZ716d6ovY7o8LfOwLhGIPFBowIb6Ln6DBW64+jCqPzUznel2hRSkQnYQqvh7/ldw8A==",
       "requires": {
         "@types/react": "^16.8.12"
       }
     },
     "autoprefixer": {
       "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+      "integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
       "requires": {
         "browserslist": "^4.8.3",
         "caniuse-lite": "^1.0.30001020",
@@ -14997,15 +1919,21 @@
       },
       "dependencies": {
         "postcss-value-parser": {
-          "version": "4.0.3"
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+          "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg=="
         }
       }
     },
     "aws-sign2": {
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1"
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
       "version": "0.21.0",
@@ -15017,10 +1945,14 @@
     },
     "babel-helper-vue-jsx-merge-props": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
+      "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==",
       "dev": true
     },
     "babel-loader": {
       "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
+      "integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
       "requires": {
         "find-cache-dir": "^2.0.0",
         "loader-utils": "^1.0.2",
@@ -15030,19 +1962,27 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "requires": {
         "object.assign": "^4.1.0"
       }
     },
     "bail": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -15055,6 +1995,8 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -15062,19 +2004,27 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
-      "version": "5.2.2"
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bin-build": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+      "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
       "requires": {
         "decompress": "^4.0.0",
         "download": "^6.2.2",
@@ -15085,6 +2035,8 @@
     },
     "bin-check": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
+      "integrity": "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==",
       "requires": {
         "execa": "^0.7.0",
         "executable": "^4.1.0"
@@ -15092,6 +2044,8 @@
     },
     "bin-version": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.1.0.tgz",
+      "integrity": "sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==",
       "requires": {
         "execa": "^1.0.0",
         "find-versions": "^3.0.0"
@@ -15099,6 +2053,8 @@
       "dependencies": {
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -15111,6 +2067,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -15119,6 +2077,8 @@
     },
     "bin-version-check": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-4.0.0.tgz",
+      "integrity": "sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==",
       "requires": {
         "bin-version": "^3.0.0",
         "semver": "^5.6.0",
@@ -15127,6 +2087,8 @@
     },
     "bin-wrapper": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.1.0.tgz",
+      "integrity": "sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==",
       "requires": {
         "bin-check": "^4.1.0",
         "bin-version-check": "^4.0.0",
@@ -15137,10 +2099,14 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "0.7.0"
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+          "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
         },
         "download": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+          "integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
           "requires": {
             "archive-type": "^4.0.0",
             "caw": "^2.0.1",
@@ -15157,15 +2123,21 @@
           },
           "dependencies": {
             "pify": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             }
           }
         },
         "file-type": {
-          "version": "8.1.0"
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
         },
         "got": {
           "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
           "requires": {
             "@sindresorhus/is": "^0.7.0",
             "cacheable-request": "^2.1.1",
@@ -15187,44 +2159,71 @@
           },
           "dependencies": {
             "pify": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             }
           }
         },
         "import-lazy": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ=="
         },
         "p-cancelable": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
         },
         "p-event": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+          "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
           "requires": {
             "p-timeout": "^2.0.1"
           }
         },
         "p-timeout": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "requires": {
             "p-finally": "^1.0.0"
           }
         },
         "pify": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
     "binary-extensions": {
-      "version": "1.13.1"
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
       "requires": {
         "readable-stream": "^3.0.1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -15235,19 +2234,27 @@
     },
     "block-stream": {
       "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
         "inherits": "~2.0.0"
       }
     },
     "bluebird": {
-      "version": "3.7.2"
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
-      "version": "4.11.8"
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -15263,6 +2270,8 @@
       "dependencies": {
         "http-errors": {
           "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -15272,10 +2281,14 @@
           }
         },
         "inherits": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "raw-body": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+          "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -15286,10 +2299,14 @@
       }
     },
     "boolbase": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boxen": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
       "requires": {
         "ansi-align": "^3.0.0",
         "camelcase": "^5.3.1",
@@ -15302,13 +2319,19 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "emoji-regex": {
-          "version": "7.0.3"
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "string-width": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -15317,6 +2340,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -15325,6 +2350,8 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15332,6 +2359,8 @@
     },
     "braces": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -15346,10 +2375,14 @@
       }
     },
     "brorand": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browserify-aes": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -15361,6 +2394,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -15369,6 +2404,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -15378,6 +2415,8 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
         "randombytes": "^2.0.1"
@@ -15385,6 +2424,8 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
         "bn.js": "^4.1.1",
         "browserify-rsa": "^4.0.0",
@@ -15397,12 +2438,16 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
         "pako": "~1.0.5"
       }
     },
     "browserslist": {
       "version": "4.8.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+      "integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
       "requires": {
         "caniuse-lite": "^1.0.30001027",
         "electron-to-chromium": "^1.3.349",
@@ -15411,6 +2456,8 @@
     },
     "buffer": {
       "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -15419,34 +2466,52 @@
     },
     "buffer-alloc": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
-      "version": "0.2.13"
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-status-codes": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bytes": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacache": {
       "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "requires": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -15467,20 +2532,28 @@
       "dependencies": {
         "lru-cache": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "y18n": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
     "cache-base": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -15495,6 +2568,8 @@
     },
     "cache-loader": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-2.0.1.tgz",
+      "integrity": "sha512-V99T3FOynmGx26Zom+JrVBytLBsmUCzVG2/4NnUKgvXN4bEV42R1ERl1IyiH/cvFIDA1Ytq2lPZ9tXDSahcQpQ==",
       "requires": {
         "loader-utils": "^1.1.0",
         "mkdirp": "^0.5.1",
@@ -15505,6 +2580,8 @@
     },
     "cacheable-request": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
       "requires": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
@@ -15516,10 +2593,14 @@
       },
       "dependencies": {
         "lowercase-keys": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
         },
         "normalize-url": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
           "requires": {
             "prepend-http": "^2.0.0",
             "query-string": "^5.0.1",
@@ -15528,6 +2609,8 @@
         },
         "sort-keys": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "requires": {
             "is-plain-obj": "^1.0.0"
           }
@@ -15535,51 +2618,71 @@
       }
     },
     "call-me-maybe": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
         "callsites": "^2.0.0"
       }
     },
     "caller-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "requires": {
         "caller-callsite": "^2.0.0"
       }
     },
     "callsites": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
-      "version": "5.3.1"
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-css": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
     "caniuse-api": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -15588,16 +2691,24 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001030"
+      "version": "1.0.30001030",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001030.tgz",
+      "integrity": "sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw=="
     },
     "case-sensitive-paths-webpack-plugin": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+      "integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ=="
     },
     "caseless": {
-      "version": "0.12.0"
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "caw": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+      "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -15607,10 +2718,14 @@
     },
     "ccount": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
       "dev": true
     },
     "chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -15619,22 +2734,32 @@
     },
     "character-entities": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-html4": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
       "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -15651,19 +2776,27 @@
       }
     },
     "chownr": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "ci-info": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -15671,6 +2804,8 @@
     },
     "class-utils": {
       "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -15680,21 +2815,29 @@
     },
     "clean-css": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "requires": {
         "source-map": "~0.6.0"
       }
     },
     "cli-boxes": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
     "cli-cursor": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
         "restore-cursor": "^2.0.0"
       }
     },
     "clipboard": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -15705,6 +2848,8 @@
     },
     "cliui": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
         "string-width": "^1.0.1",
@@ -15713,10 +2858,14 @@
       }
     },
     "clone": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-deep": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "requires": {
         "is-plain-object": "^2.0.4",
@@ -15726,12 +2875,16 @@
     },
     "clone-response": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
     },
     "coa": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "requires": {
         "@types/q": "^1.5.1",
         "chalk": "^2.4.1",
@@ -15739,14 +2892,20 @@
       }
     },
     "code-point-at": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collapse-white-space": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -15754,6 +2913,8 @@
     },
     "color": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -15761,20 +2922,28 @@
     },
     "color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
         "color-name": "1.1.3"
       },
       "dependencies": {
         "color-name": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
     "color-name": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
       "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -15782,6 +2951,8 @@
     },
     "columnify": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "requires": {
         "strip-ansi": "^3.0.0",
         "wcwidth": "^1.0.0"
@@ -15789,28 +2960,42 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "comma-separated-tokens": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
       "dev": true
     },
     "commander": {
-      "version": "2.20.3"
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -15820,6 +3005,8 @@
     },
     "config-chain": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -15827,6 +3014,8 @@
     },
     "configstore": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -15837,59 +3026,87 @@
       }
     },
     "connect-history-api-fallback": {
-      "version": "1.6.0"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "console-browserify": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
     "console-control-strings": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "console-stream": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+      "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ="
     },
     "consolidate": {
       "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
+      "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
       "requires": {
         "bluebird": "^3.1.1"
       }
     },
     "constants-browserify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "content-disposition": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "requires": {
         "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
     "content-type": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "requires": {
         "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
     "cookie": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -15900,28 +3117,40 @@
       }
     },
     "copy-descriptor": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.6.4"
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "core-js-compat": {
       "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+      "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
       "requires": {
         "browserslist": "^4.8.3",
         "semver": "7.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.0.0"
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
         }
       }
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
@@ -15931,6 +3160,8 @@
     },
     "create-ecdh": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
@@ -15938,6 +3169,8 @@
     },
     "create-hash": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -15948,6 +3181,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -15959,6 +3194,8 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -15969,6 +3206,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -15984,20 +3223,28 @@
       }
     },
     "crypto-random-string": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css-blank-pseudo": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+      "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.5"
       }
     },
     "css-color-names": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "requires": {
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
@@ -16005,6 +3252,8 @@
     },
     "css-has-pseudo": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+      "integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.6",
@@ -16013,10 +3262,14 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
           "dev": true
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "dev": true,
           "requires": {
             "cssesc": "^2.0.0",
@@ -16028,6 +3281,8 @@
     },
     "css-loader": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+      "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
       "requires": {
         "camelcase": "^5.2.0",
         "icss-utils": "^4.1.0",
@@ -16044,6 +3299,8 @@
     },
     "css-prefers-color-scheme": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+      "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.5"
@@ -16051,6 +3308,8 @@
     },
     "css-select": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
         "css-what": "2.1",
@@ -16060,6 +3319,8 @@
       "dependencies": {
         "domutils": {
           "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "requires": {
             "dom-serializer": "0",
             "domelementtype": "1"
@@ -16068,10 +3329,14 @@
       }
     },
     "css-select-base-adapter": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
       "requires": {
         "mdn-data": "2.0.4",
         "source-map": "^0.6.1"
@@ -16079,20 +3344,30 @@
     },
     "css-unit-converter": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
       "dev": true
     },
     "css-what": {
-      "version": "2.1.3"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "cssdb": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
+      "integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==",
       "dev": true
     },
     "cssesc": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
       "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+      "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
       "requires": {
         "cosmiconfig": "^5.0.0",
         "cssnano-preset-default": "^4.0.7",
@@ -16102,6 +3377,8 @@
     },
     "cssnano-preset-default": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+      "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
       "requires": {
         "css-declaration-sorter": "^4.0.1",
         "cssnano-util-raw-cache": "^4.0.1",
@@ -16136,37 +3413,53 @@
       }
     },
     "cssnano-util-get-arguments": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8="
     },
     "cssnano-util-get-match": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0="
     },
     "cssnano-util-raw-cache": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "cssnano-util-same-parent": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
     },
     "csso": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+      "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
       "requires": {
         "css-tree": "1.0.0-alpha.37"
       }
     },
     "csstype": {
-      "version": "2.6.9"
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
         "array-find-index": "^1.0.1"
       }
     },
     "cwebp-bin": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",
+      "integrity": "sha512-BsPKStaNr98zfxwejWWLIGELbPERULJoD2v5ijvpeutSAGsegX7gmABgnkRK7MUucCPROXXfaPqkLAwI509JzA==",
       "requires": {
         "bin-build": "^3.0.0",
         "bin-wrapper": "^4.0.1",
@@ -16174,39 +3467,57 @@
       }
     },
     "cyclist": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "dashdash": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "dateformat": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "de-indent": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       },
       "dependencies": {
         "ms": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "decamelize": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -16219,18 +3530,24 @@
       },
       "dependencies": {
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "decompress-response": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -16239,6 +3556,8 @@
       "dependencies": {
         "bl": {
           "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -16246,6 +3565,8 @@
         },
         "tar-stream": {
           "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -16260,6 +3581,8 @@
     },
     "decompress-tarbz2": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -16269,12 +3592,16 @@
       },
       "dependencies": {
         "file-type": {
-          "version": "6.2.0"
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
         }
       }
     },
     "decompress-targz": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -16283,6 +3610,8 @@
     },
     "decompress-unzip": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -16291,55 +3620,77 @@
       },
       "dependencies": {
         "file-type": {
-          "version": "3.9.0"
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "deep-extend": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deepmerge": {
-      "version": "4.2.2"
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "defaults": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
         "clone": "^1.0.2"
       }
     },
     "defer-to-connect": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "define-properties": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
       }
     },
     "define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "requires": {
         "is-descriptor": "^0.1.0"
       },
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16348,12 +3699,16 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16362,6 +3717,8 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -16369,56 +3726,82 @@
           }
         },
         "kind-of": {
-          "version": "5.1.0"
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
     },
     "defined": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "dev": true,
       "optional": true
     },
     "delegates": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detab": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
+      "integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
       "dev": true,
       "requires": {
         "repeat-string": "^1.5.4"
       }
     },
     "detect-indent": {
-      "version": "6.0.0"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
     },
     "detect-libc": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
     },
     "detective": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "dev": true,
       "requires": {
         "acorn-node": "^1.6.1",
@@ -16427,10 +3810,14 @@
       }
     },
     "didyoumean": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+      "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8="
     },
     "diffie-hellman": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -16439,6 +3826,8 @@
     },
     "dir-glob": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
         "arrify": "^1.0.1",
         "path-type": "^3.0.0"
@@ -16446,30 +3835,42 @@
     },
     "dom-converter": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
       }
     },
     "dom-serializer": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         }
       }
     },
     "domain-browser": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "domelementtype": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+      "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1"
@@ -16477,12 +3878,16 @@
       "dependencies": {
         "domelementtype": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
           "dev": true
         }
       }
     },
     "domutils": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -16490,15 +3895,21 @@
     },
     "dot-prop": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
         "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
-      "version": "6.2.0"
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "download": {
       "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+      "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
       "requires": {
         "caw": "^2.0.0",
         "content-disposition": "^0.5.2",
@@ -16514,10 +3925,14 @@
       }
     },
     "duplexer3": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -16527,19 +3942,27 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.360"
+      "version": "1.3.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.360.tgz",
+      "integrity": "sha512-RE1pv2sjQiDRRN1nI0fJ0eQHZ9le4oobu16OArnwEUV5ycAU5SNjFyvzjZ1gPUAqBa2Ud1XagtW8j3ZXfHuQHA=="
     },
     "elliptic": {
       "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -16552,22 +3975,32 @@
     },
     "emoji-regex": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
       "dev": true
     },
     "emojis-list": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -16576,6 +4009,8 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
           "requires": {
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
@@ -16584,36 +4019,50 @@
       }
     },
     "entities": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
     },
     "envinfo": {
-      "version": "7.5.0"
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
+      "integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
     },
     "errno": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
       }
     },
     "error-ex": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       },
       "dependencies": {
         "is-arrayish": {
-          "version": "0.2.1"
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         }
       }
     },
     "error-stack-parser": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
       "requires": {
         "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
       "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -16630,6 +4079,8 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -16637,50 +4088,74 @@
       }
     },
     "escape-html": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-scope": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
     },
     "esprima": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
         "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
-      "version": "4.3.0"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
-      "version": "1.8.1"
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
     },
     "eventsource": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "requires": {
         "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -16688,6 +4163,8 @@
     },
     "exec-buffer": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+      "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "requires": {
         "execa": "^0.7.0",
         "p-finally": "^1.0.0",
@@ -16698,6 +4175,8 @@
     },
     "execa": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -16710,6 +4189,8 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -16720,17 +4201,23 @@
     },
     "executable": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
       "requires": {
         "pify": "^2.2.0"
       },
       "dependencies": {
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "expand-brackets": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -16742,10 +4229,14 @@
       }
     },
     "expand-template": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "express": {
       "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -16780,15 +4271,21 @@
       },
       "dependencies": {
         "path-to-regexp": {
-          "version": "0.1.7"
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
     "express-graphql": {
       "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
+      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
       "requires": {
         "accepts": "^1.3.7",
         "content-type": "^1.0.4",
@@ -16798,28 +4295,38 @@
     },
     "ext-list": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "requires": {
         "mime-db": "^1.28.0"
       }
     },
     "ext-name": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
         "is-extendable": "^0.1.0"
       }
     },
     "extglob": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -16833,6 +4340,8 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -16840,13 +4349,19 @@
       }
     },
     "extsprintf": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-glob": {
       "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
@@ -16857,55 +4372,83 @@
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         }
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fastq": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
       "requires": {
         "reusify": "^1.0.0"
       }
     },
     "faye-websocket": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
     },
     "fd-slicer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
-      "version": "3.5.1"
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
     },
     "figures": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
     },
     "file-loader": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+      "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
       "requires": {
         "loader-utils": "^1.0.2",
         "schema-utils": "^1.0.0"
       }
     },
     "file-type": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filename-reserved-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -16914,6 +4457,8 @@
     },
     "fill-range": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -16923,6 +4468,8 @@
     },
     "finalhandler": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -16935,6 +4482,8 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "requires": {
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
@@ -16943,34 +4492,46 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
           }
         },
         "pify": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
     "find-up": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
         "locate-path": "^2.0.0"
       }
     },
     "find-versions": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "requires": {
         "semver-regex": "^2.0.0"
       }
     },
     "flatten": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
@@ -16982,13 +4543,19 @@
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -16996,19 +4563,27 @@
       }
     },
     "forwarded": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
       }
     },
     "fresh": {
-      "version": "0.5.2"
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "friendly-errors-webpack-plugin": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz",
+      "integrity": "sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==",
       "requires": {
         "chalk": "^1.1.3",
         "error-stack-parser": "^2.0.0",
@@ -17016,13 +4591,19 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -17033,6 +4614,8 @@
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -17040,6 +4623,8 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -17047,22 +4632,30 @@
           }
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "from2": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
     },
     "fs-constants": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -17071,12 +4664,16 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "requires": {
         "minipass": "^3.0.0"
       }
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -17085,10 +4682,24 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
     },
     "fstream": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -17098,14 +4709,20 @@
       }
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fuse.js": {
       "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.6.tgz",
+      "integrity": "sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -17119,47 +4736,69 @@
     },
     "gaze": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
       }
     },
     "gensync": {
-      "version": "1.0.0-beta.1"
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
     },
     "get-caller-file": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-proxy": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+      "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "requires": {
         "npm-conf": "^1.1.0"
       }
     },
     "get-stdin": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "git-hooks-list": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.2.tgz",
+      "integrity": "sha512-C3c/FG6Pgh053+yK/CnNNYJo5mgCa3OeI+cPxPIl0tyMLm1mGfiV0NX0LrhnjVoX7dfkR78WyW2kvFVHvAlneg=="
     },
     "github-from-package": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "github-slugger": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
       "dev": true,
       "requires": {
         "emoji-regex": ">=6.0.0 <=6.1.1"
@@ -17167,6 +4806,8 @@
     },
     "glob": {
       "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17178,6 +4819,8 @@
     },
     "glob-parent": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -17185,6 +4828,8 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -17192,19 +4837,27 @@
       }
     },
     "glob-to-regexp": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-dirs": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
         "ini": "^1.3.4"
       }
     },
     "globals": {
-      "version": "11.12.0"
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "requires": {
         "array-union": "^1.0.1",
         "dir-glob": "2.0.0",
@@ -17216,12 +4869,16 @@
       },
       "dependencies": {
         "slash": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         }
       }
     },
     "globule": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -17231,6 +4888,8 @@
     },
     "good-listener": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -17239,6 +4898,8 @@
     },
     "got": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
         "decompress-response": "^3.2.0",
         "duplexer3": "^0.1.4",
@@ -17257,10 +4918,14 @@
       },
       "dependencies": {
         "prepend-http": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "url-parse-lax": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -17268,39 +4933,54 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3"
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "graceful-readlink": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphql": {
       "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
       "requires": {
         "iterall": "^1.2.2"
       }
     },
     "graphql-compose": {
       "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-7.12.3.tgz",
+      "integrity": "sha512-fgsVhL5eePcwIgQra70jYQErxQ+z3LBz9WIKhcn05XN/FNF5vbIZ/hj8UAWYu8UShsM5434u0wDONuGClsxg+A==",
       "requires": {
         "graphql-type-json": "^0.3.1",
         "object-path": "^0.11.4"
       }
     },
     "graphql-playground-html": {
-      "version": "1.6.12"
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.12.tgz",
+      "integrity": "sha512-yOYFwwSMBL0MwufeL8bkrNDgRE7eF/kTHiwrqn9FiR9KLcNIl1xw9l9a+6yIRZM56JReQOHpbQFXTZn1IuSKRg=="
     },
     "graphql-playground-middleware-express": {
       "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.12.tgz",
+      "integrity": "sha512-17szgonnVSxWVrgblLRHHLjWnMUONfkULIwSunaMvYx8k5oG3yL86cyGCbHuDFUFkyr2swLhdfYl4mDfDXuvOA==",
       "requires": {
         "graphql-playground-html": "1.6.12"
       }
     },
     "graphql-type-json": {
       "version": "0.3.1",
-      "requires": {}
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.1.tgz",
+      "integrity": "sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA=="
     },
     "gray-matter": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
+      "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.11.0",
@@ -17311,6 +4991,8 @@
     },
     "gridsome": {
       "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/gridsome/-/gridsome-0.7.13.tgz",
+      "integrity": "sha512-EQMJfoLZpRRWR7gNB9ahkSTIn/QjanvyRJOS853NhhWhfHCgvQOO+DYu7EHvXF0afny43WOSiXOk0WYnolYGUg==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/core": "^7.0.0",
@@ -17395,12 +5077,16 @@
       "dependencies": {
         "dir-glob": {
           "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+          "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
           "requires": {
             "path-type": "^3.0.0"
           }
         },
         "globby": {
           "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+          "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
           "requires": {
             "@types/glob": "^7.1.1",
             "array-union": "^1.0.2",
@@ -17413,27 +5099,39 @@
           }
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "lru-cache": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "pify": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         },
         "tapable": {
-          "version": "2.0.0-beta.5"
+          "version": "2.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.0.0-beta.5.tgz",
+          "integrity": "sha512-P4o84kC8CD66ZuCs6noh3QLU2ZuaBvMl0yCmp9rr0GXZyIfLd1sB2ZvJZjitQgfds8GDKRLmiiAcssr2bEHQ0A=="
         },
         "yallist": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
     "gridsome-plugin-tailwindcss": {
       "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/gridsome-plugin-tailwindcss/-/gridsome-plugin-tailwindcss-2.2.36.tgz",
+      "integrity": "sha512-ot42j3X3mz8Skmt5mHVDu13JgNp9fmfOQ1Ki+Qw95i+bfpGSynFUxO2ChI4KlDmubR8Ma96QRrVewdm4t4CQjw==",
       "dev": true,
       "requires": {
         "@fullhuman/postcss-purgecss": "^2.0.6",
@@ -17443,10 +5141,14 @@
       }
     },
     "har-schema": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -17454,36 +5156,52 @@
     },
     "has": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
     },
     "has-symbols": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -17492,6 +5210,8 @@
     },
     "has-values": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -17499,6 +5219,8 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -17506,20 +5228,28 @@
       }
     },
     "has-yarn": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
     "hash-base": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
     "hash-sum": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ="
     },
     "hash.js": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -17527,14 +5257,20 @@
     },
     "hast-util-is-element": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
+      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==",
       "dev": true
     },
     "hast-util-parse-selector": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
+      "integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q==",
       "dev": true
     },
     "hast-util-sanitize": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
+      "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
       "dev": true,
       "requires": {
         "xtend": "^4.0.1"
@@ -17542,6 +5278,8 @@
     },
     "hast-util-to-html": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz",
+      "integrity": "sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==",
       "dev": true,
       "requires": {
         "ccount": "^1.0.0",
@@ -17558,6 +5296,8 @@
       "dependencies": {
         "property-information": {
           "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
+          "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
           "dev": true,
           "requires": {
             "xtend": "^4.0.1"
@@ -17565,16 +5305,22 @@
         },
         "unist-util-is": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
+          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
           "dev": true
         }
       }
     },
     "hast-util-whitespace": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.3.tgz",
+      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA==",
       "dev": true
     },
     "hastscript": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
+      "integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
       "dev": true,
       "requires": {
         "comma-separated-tokens": "^1.0.0",
@@ -17584,16 +5330,24 @@
       }
     },
     "he": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hex-color-regex": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "hirestime": {
-      "version": "3.2.2"
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/hirestime/-/hirestime-3.2.2.tgz",
+      "integrity": "sha512-X+4w5O6JMW7zlgAhad6OPA/MwYTW1FqrF27+6ItRUmDT4jklsXd4N5S5hNCmd9AIGVp8SLsCoGwRe5ddBp/CKg=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -17601,22 +5355,34 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.6"
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.6.tgz",
+      "integrity": "sha512-Kp6rShEsCHhF5dD3EWKdkgVA8ix90oSUJ0VY4g9goxxa0+f4lx63muTftn0mlJ/+8IESGWyKnP//V2D7S4ZbIQ=="
     },
     "hsl-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
     },
     "hsla-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
     },
     "html-comment-regex": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "html-entities": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-minifier": {
       "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "requires": {
         "camel-case": "3.0.x",
         "clean-css": "4.2.x",
@@ -17628,15 +5394,21 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1"
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
         }
       }
     },
     "html-tags": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
     },
     "html-to-text": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-4.0.0.tgz",
+      "integrity": "sha512-QQl5EEd97h6+3crtgBhkEAO6sQnZyDff8DAeJzoSkOc1Dqe1UvTUZER0B+KjBe6fPZqq549l2VUhtracus3ndA==",
       "dev": true,
       "requires": {
         "he": "^1.0.0",
@@ -17647,10 +5419,14 @@
     },
     "html-void-elements": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
+      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
       "dev": true
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "requires": {
         "html-minifier": "^3.2.3",
         "loader-utils": "^0.2.16",
@@ -17662,16 +5438,24 @@
       },
       "dependencies": {
         "big.js": {
-          "version": "3.2.0"
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
         },
         "emojis-list": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
         },
         "json5": {
-          "version": "0.5.1"
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "loader-utils": {
           "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "requires": {
             "big.js": "^3.1.3",
             "emojis-list": "^2.0.0",
@@ -17681,6 +5465,8 @@
         },
         "util.promisify": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+          "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
           "requires": {
             "define-properties": "^1.1.2",
             "object.getownpropertydescriptors": "^2.0.3"
@@ -17690,6 +5476,8 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -17701,15 +5489,21 @@
       "dependencies": {
         "domhandler": {
           "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
             "domelementtype": "1"
           }
         },
         "entities": {
-          "version": "1.1.2"
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -17719,10 +5513,14 @@
       }
     },
     "http-cache-semantics": {
-      "version": "3.8.1"
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-errors": {
       "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -17732,10 +5530,14 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10"
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-signature": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -17743,34 +5545,50 @@
       }
     },
     "https-browserify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "icss-replace-symbols": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
     "icss-utils": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "requires": {
         "postcss": "^7.0.14"
       }
     },
     "ieee754": {
-      "version": "1.1.13"
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
-      "version": "3.3.10"
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "imagemin": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-6.1.0.tgz",
+      "integrity": "sha512-8ryJBL1CN5uSHpiBMX0rJw79C9F9aJqMnjGnrd/1CafegpNuA81RBAAru/jQQEOWlOJJlpRnlcVFF6wq+Ist0A==",
       "requires": {
         "file-type": "^10.7.0",
         "globby": "^8.0.1",
@@ -17781,15 +5599,21 @@
       },
       "dependencies": {
         "file-type": {
-          "version": "10.11.0"
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+          "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
         },
         "pify": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
     "imagemin-mozjpeg": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-mozjpeg/-/imagemin-mozjpeg-8.0.0.tgz",
+      "integrity": "sha512-+EciPiIjCb8JWjQNr1q8sYWYf7GDCNDxPYnkD11TNIjjWNzaV+oTg4DpOPQjl5ZX/KRCPMEgS79zLYAQzLitIA==",
       "requires": {
         "execa": "^1.0.0",
         "is-jpg": "^2.0.0",
@@ -17798,6 +5622,8 @@
       "dependencies": {
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -17810,6 +5636,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -17818,6 +5646,8 @@
     },
     "imagemin-pngquant": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-7.0.0.tgz",
+      "integrity": "sha512-FXBz8lfvI+noraZbNCE0AUDUng/2+Cv5W0F/nUGGjKdzb8AnN1f0JzVxH2aYj7SQxOdYYatvfNbITIZpaFATZg==",
       "requires": {
         "execa": "^1.0.0",
         "is-png": "^1.0.0",
@@ -17828,6 +5658,8 @@
       "dependencies": {
         "execa": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -17840,6 +5672,8 @@
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -17848,6 +5682,8 @@
     },
     "imagemin-webp": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-5.1.0.tgz",
+      "integrity": "sha512-BsPTpobgbDPFBBsI3UflnU/cpIVa15qInEDBcYBw16qI/6XiB4vDF/dGp9l4aM3pfFDDYqR0mANMcKpBD7wbCw==",
       "requires": {
         "cwebp-bin": "^5.0.0",
         "exec-buffer": "^3.0.0",
@@ -17856,12 +5692,16 @@
     },
     "import-cwd": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "requires": {
         "import-from": "^2.1.0"
       }
     },
     "import-fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
@@ -17869,47 +5709,69 @@
     },
     "import-from": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
         "resolve-from": "^3.0.0"
       }
     },
     "import-lazy": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "imurmurhash": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "in-publish": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
         "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "infer-owner": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5"
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "into-stream": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "requires": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -17917,32 +5779,46 @@
     },
     "invariant": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.9.1"
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-absolute-url": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "requires": {
         "kind-of": "^6.0.0"
       }
     },
     "is-alphabetical": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumerical": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -17950,28 +5826,40 @@
       }
     },
     "is-arrayish": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-binary-path": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
         "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.1.5"
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-ci": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
         "ci-info": "^2.0.0"
       }
     },
     "is-color-stop": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "requires": {
         "css-color-names": "^0.0.4",
         "hex-color-regex": "^1.1.0",
@@ -17983,30 +5871,42 @@
     },
     "is-cwebp-readable": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-cwebp-readable/-/is-cwebp-readable-2.0.1.tgz",
+      "integrity": "sha1-r7k7DAq9CiUQEBauM66ort+SbSY=",
       "requires": {
         "file-type": "^4.3.0"
       },
       "dependencies": {
         "file-type": {
-          "version": "4.4.0"
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
         }
       }
     },
     "is-data-descriptor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "requires": {
         "kind-of": "^6.0.0"
       }
     },
     "is-date-object": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-decimal": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "requires": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -18014,54 +5914,80 @@
       }
     },
     "is-directory": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-extendable": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
     "is-hexadecimal": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
       }
     },
     "is-jpg": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
+      "integrity": "sha1-LhmX+m6RZuqsAkLarkQ0A+TvHZc="
     },
     "is-natural-number": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
     "is-npm": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
     },
     "is-number": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -18069,121 +5995,181 @@
       }
     },
     "is-obj": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-path-inside": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
       }
     },
     "is-png": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84="
     },
     "is-regex": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-relative": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "requires": {
         "is-unc-path": "^1.0.0"
       }
     },
     "is-resolvable": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-retry-allowed": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-svg": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+      "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "requires": {
         "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
         "unc-path-regex": "^0.1.2"
       }
     },
     "is-url": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "is-utf8": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-whitespace-character": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-windows": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "is-word-character": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "is-wsl": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "is-yarn-global": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "isurl": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
       }
     },
     "iterall": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "javascript-stringify": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
+      "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow=="
     },
     "jest-worker": {
       "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
+      "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
       "requires": {
         "merge-stream": "^1.0.1",
         "supports-color": "^6.1.0"
@@ -18191,6 +6177,8 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18199,59 +6187,89 @@
     },
     "js-base64": {
       "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
     "jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
-      "version": "2.5.2"
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-loader": {
-      "version": "0.5.7"
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
     },
     "json-parse-better-errors": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
-      "version": "3.3.3"
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "json5": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
         "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -18261,15 +6279,21 @@
     },
     "keyv": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
       "requires": {
         "json-buffer": "3.0.0"
       }
     },
     "kind-of": {
-      "version": "6.0.3"
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
       "requires": {
         "lodash": "^4.17.5",
         "webpack-sources": "^1.1.0"
@@ -18277,28 +6301,38 @@
     },
     "latest-version": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "requires": {
         "package-json": "^6.3.0"
       }
     },
     "lcid": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
     },
     "leven": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
     },
     "levenary": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+      "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
       "requires": {
         "leven": "^3.1.0"
       }
     },
     "load-json-file": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -18309,20 +6343,28 @@
       "dependencies": {
         "parse-json": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
             "error-ex": "^1.2.0"
           }
         },
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "loader-runner": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
     },
     "loader-utils": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -18331,48 +6373,72 @@
     },
     "locate-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.15"
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.deburr": {
-      "version": "4.1.0"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.kebabcase": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
     },
     "lodash.memoize": {
-      "version": "4.1.2"
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.mergewith": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -18380,19 +6446,27 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
     },
     "lodash.toarray": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
     "lodash.uniq": {
-      "version": "4.5.0"
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-update": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "requires": {
         "ansi-escapes": "^3.0.0",
         "cli-cursor": "^2.0.0",
@@ -18400,10 +6474,14 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -18411,12 +6489,16 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
           }
         },
         "wrap-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0"
@@ -18426,6 +6508,8 @@
     },
     "logalot": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+      "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "requires": {
         "figures": "^1.3.5",
         "squeak": "^1.0.0"
@@ -18433,6 +6517,8 @@
       "dependencies": {
         "figures": {
           "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
             "escape-string-regexp": "^1.0.5",
             "object-assign": "^4.1.0"
@@ -18441,32 +6527,46 @@
       }
     },
     "lokijs": {
-      "version": "1.5.8"
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.8.tgz",
+      "integrity": "sha512-D8E3TBrY35o1ELnonp2MF8b3wKu2tVNl2TqRjvS+95oPMMe7OoIAxNY1qr+5BEZwnWn2V4ErAjVt000DonM+FA=="
     },
     "longest": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lpad-align": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+      "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "requires": {
         "get-stdin": "^4.0.1",
         "indent-string": "^2.1.0",
@@ -18476,46 +6576,66 @@
     },
     "lru-cache": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       },
       "dependencies": {
         "yallist": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
     },
     "make-dir": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "^3.0.0"
       }
     },
     "mamacro": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
     },
     "map-cache": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-visit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
       }
     },
     "markdown-escapes": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
     "md5-file": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
     },
     "md5.js": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -18524,6 +6644,8 @@
     },
     "mdast-squeeze-paragraphs": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
+      "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
       "dev": true,
       "requires": {
         "unist-util-remove": "^1.0.0"
@@ -18531,6 +6653,8 @@
     },
     "mdast-util-definitions": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
+      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.0.0"
@@ -18538,6 +6662,8 @@
     },
     "mdast-util-to-hast": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
+      "integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.0",
@@ -18555,20 +6681,30 @@
     },
     "mdast-util-to-string": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.8.tgz",
+      "integrity": "sha512-GBracya0dOzckEEizUBzfrkWRLCHMsppuU97LPUriY9kWnYyGFWTx4VDW+sUcj2LneBz/Tp1aYp3aUCibzjtWg==",
       "dev": true
     },
     "mdn-data": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "mdurl": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
     "media-typer": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memory-fs": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -18576,6 +6712,8 @@
     },
     "meow": {
       "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -18590,28 +6728,40 @@
       }
     },
     "merge-descriptors": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-source-map": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "requires": {
         "source-map": "^0.6.1"
       }
     },
     "merge-stream": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
         "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
     },
     "methods": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -18630,6 +6780,8 @@
       "dependencies": {
         "define-property": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -18637,6 +6789,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -18644,6 +6798,8 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -18652,31 +6808,45 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
     },
     "mime": {
-      "version": "2.4.4"
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
-      "version": "1.43.0"
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
         "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mimic-response": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
+      "integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
       "requires": {
         "loader-utils": "^1.1.0",
         "schema-utils": "^1.0.0",
@@ -18684,16 +6854,24 @@
       }
     },
     "mini-svg-data-uri": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.1.3.tgz",
+      "integrity": "sha512-EeKOmdzekjdPe53/GdxmUpNgDQFkNeSte6XkJmOBt4BfWL6FQ9G9RtLNh+JMjFS3LhdpSICMIkZdznjiecASHQ=="
     },
     "minimalistic-assert": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -18705,12 +6883,16 @@
     },
     "minipass": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
       "requires": {
         "yallist": "^4.0.0"
       }
     },
     "minizlib": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -18718,6 +6900,8 @@
     },
     "mississippi": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "requires": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
@@ -18733,6 +6917,8 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -18740,6 +6926,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -18748,20 +6936,28 @@
     },
     "mkdirp": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8"
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "moment": {
-      "version": "2.24.0"
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -18773,6 +6969,8 @@
     },
     "mozjpeg": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mozjpeg/-/mozjpeg-6.0.1.tgz",
+      "integrity": "sha512-9Z59pJMi8ni+IUvSH5xQwK5tNLw7p3dwDNCZ3o1xE+of3G5Hc/yOz6Ue/YuLiBXU3ZB5oaHPURyPdqfBX/QYJA==",
       "requires": {
         "bin-build": "^3.0.0",
         "bin-wrapper": "^4.0.0",
@@ -18780,13 +6978,19 @@
       }
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.14.0"
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanomatch": {
       "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -18803,6 +7007,8 @@
       "dependencies": {
         "define-property": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -18810,6 +7016,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -18817,6 +7025,8 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -18824,34 +7034,50 @@
       }
     },
     "napi-build-utils": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
     },
     "negotiator": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
-      "version": "2.6.1"
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "next-tick": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "no-case": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
       }
     },
     "node-abi": {
       "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
+      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
       "requires": {
         "semver": "^5.4.1"
       }
     },
     "node-emoji": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "dev": true,
       "requires": {
         "lodash.toarray": "^4.4.0"
@@ -18859,6 +7085,8 @@
     },
     "node-gyp": {
       "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
         "fstream": "^1.0.0",
@@ -18877,12 +7105,16 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "node-libs-browser": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "requires": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -18910,23 +7142,31 @@
       },
       "dependencies": {
         "punycode": {
-          "version": "1.4.1"
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "node-releases": {
       "version": "1.1.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
+      "integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
       "requires": {
         "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
     "node-sass": {
       "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -18950,10 +7190,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -18965,6 +7209,8 @@
         },
         "cross-spawn": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -18973,15 +7219,21 @@
         },
         "supports-color": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "noop-logger": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -18989,6 +7241,8 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -18997,20 +7251,30 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "normalize.css": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "dev": true
     },
     "npm-conf": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -19018,12 +7282,16 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
       }
     },
     "npmlog": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -19033,24 +7301,36 @@
     },
     "nth-check": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -19059,6 +7339,8 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -19066,22 +7348,32 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-keys": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
-      "version": "0.11.4"
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object-visit": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
       }
     },
     "object.assign": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -19091,6 +7383,8 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -19098,12 +7392,16 @@
     },
     "object.pick": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
       }
     },
     "object.values": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -19113,24 +7411,32 @@
     },
     "on-finished": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
       }
     },
     "once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
       }
     },
     "onetime": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
         "minimist": "~0.0.1",
@@ -19139,12 +7445,16 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
       }
     },
     "optimize-css-assets-webpack-plugin": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
+      "integrity": "sha512-q9fbvCRS6EYtUKKSwI87qm2IxlyJK5b4dygW1rKUBT6mMDhdG5e5bZT63v6tnJR9F9FB/H5a0HTmtw+laUBxKA==",
       "requires": {
         "cssnano": "^4.1.10",
         "last-call-webpack-plugin": "^3.0.0"
@@ -19152,25 +7462,35 @@
     },
     "original": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "requires": {
         "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-filter-obj": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
+      "integrity": "sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==",
       "requires": {
         "arch": "^2.1.0"
       }
     },
     "os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
         "lcid": "^1.0.0"
@@ -19178,10 +7498,14 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -19189,61 +7513,89 @@
       }
     },
     "ow": {
-      "version": "0.8.0"
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.8.0.tgz",
+      "integrity": "sha512-hYgYZNcRfIZ2JppSTqh6mxdU1zkUXsGlwy4eBsRG91R6CiZk7cB+AfHl+SVKBdynQvAnNHNfu0ZrtJN1jj7Mow=="
     },
     "p-cancelable": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-event": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+      "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
       "requires": {
         "p-timeout": "^1.1.1"
       }
     },
     "p-finally": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
         "p-try": "^1.0.0"
       }
     },
     "p-locate": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
       }
     },
     "p-map": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-map-series": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+      "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
       "requires": {
         "p-reduce": "^1.0.0"
       }
     },
     "p-pipe": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+      "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
     },
     "p-reduce": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
     },
     "p-timeout": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
         "p-finally": "^1.0.0"
       }
     },
     "p-try": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "requires": {
         "got": "^9.6.0",
         "registry-auth-token": "^4.0.0",
@@ -19253,6 +7605,8 @@
       "dependencies": {
         "cacheable-request": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
           "requires": {
             "clone-response": "^1.0.2",
             "get-stream": "^5.1.0",
@@ -19265,23 +7619,31 @@
           "dependencies": {
             "get-stream": {
               "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
               "requires": {
                 "pump": "^3.0.0"
               }
             },
             "lowercase-keys": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
             }
           }
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "got": {
           "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
           "requires": {
             "@sindresorhus/is": "^0.14.0",
             "@szmarczak/http-timer": "^1.1.2",
@@ -19297,30 +7659,44 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.0.4"
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+          "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
         },
         "keyv": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+          "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
           "requires": {
             "json-buffer": "3.0.0"
           }
         },
         "normalize-url": {
-          "version": "4.5.0"
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         },
         "p-cancelable": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         },
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
     "pako": {
-      "version": "1.0.11"
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "requires": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
@@ -19329,12 +7705,16 @@
     },
     "param-case": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
       }
     },
     "parse-asn1": {
       "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
@@ -19346,6 +7726,8 @@
     },
     "parse-entities": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -19358,49 +7740,75 @@
     },
     "parse-json": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
     },
     "parseurl": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascalcase": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "path-dirname": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
     },
     "path-type": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
         "pify": "^3.0.0"
       }
     },
     "pbkdf2": {
       "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -19410,43 +7818,63 @@
       }
     },
     "pend": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "physical-cpu-count": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
+      "integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA="
     },
     "picomatch": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "requires": {
         "find-up": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "requires": {
             "locate-path": "^3.0.0"
           }
         },
         "locate-path": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -19454,23 +7882,31 @@
         },
         "p-limit": {
           "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "requires": {
             "p-limit": "^2.0.0"
           }
         },
         "p-try": {
-          "version": "2.2.0"
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         }
       }
     },
     "pngquant-bin": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-5.0.2.tgz",
+      "integrity": "sha512-OLdT+4JZx5BqE1CFJkrvomYV0aSsv6x2Bba+aWaVc0PMfWlE+ZByNKYAdKeIqsM4uvW1HOSEHnf8KcOnykPNxA==",
       "requires": {
         "bin-build": "^3.0.0",
         "bin-wrapper": "^4.0.1",
@@ -19480,6 +7916,8 @@
       "dependencies": {
         "execa": {
           "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
@@ -19494,6 +7932,8 @@
     },
     "portfinder": {
       "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
       "requires": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
@@ -19502,6 +7942,8 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -19509,10 +7951,14 @@
       }
     },
     "posix-character-classes": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
       "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -19521,6 +7967,8 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19529,6 +7977,8 @@
     },
     "postcss-attribute-case-insensitive": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
+      "integrity": "sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19537,6 +7987,8 @@
     },
     "postcss-calc": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
+      "integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
       "requires": {
         "postcss": "^7.0.27",
         "postcss-selector-parser": "^6.0.2",
@@ -19544,12 +7996,16 @@
       },
       "dependencies": {
         "postcss-value-parser": {
-          "version": "4.0.3"
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+          "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg=="
         }
       }
     },
     "postcss-color-functional-notation": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+      "integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19558,6 +8014,8 @@
     },
     "postcss-color-gray": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+      "integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
       "dev": true,
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -19567,6 +8025,8 @@
     },
     "postcss-color-hex-alpha": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+      "integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.14",
@@ -19575,6 +8035,8 @@
     },
     "postcss-color-mod-function": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+      "integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
       "dev": true,
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -19584,6 +8046,8 @@
     },
     "postcss-color-rebeccapurple": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+      "integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19592,6 +8056,8 @@
     },
     "postcss-colormin": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "requires": {
         "browserslist": "^4.0.0",
         "color": "^3.0.0",
@@ -19602,6 +8068,8 @@
     },
     "postcss-convert-values": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "requires": {
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
@@ -19609,6 +8077,8 @@
     },
     "postcss-custom-media": {
       "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+      "integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
@@ -19616,6 +8086,8 @@
     },
     "postcss-custom-properties": {
       "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+      "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.17",
@@ -19624,6 +8096,8 @@
     },
     "postcss-custom-selectors": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+      "integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19632,10 +8106,14 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
           "dev": true
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "dev": true,
           "requires": {
             "cssesc": "^2.0.0",
@@ -19647,6 +8125,8 @@
     },
     "postcss-dir-pseudo-class": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+      "integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19655,10 +8135,14 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
           "dev": true
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "dev": true,
           "requires": {
             "cssesc": "^2.0.0",
@@ -19670,30 +8154,40 @@
     },
     "postcss-discard-comments": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "postcss-discard-duplicates": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "postcss-discard-empty": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "postcss-discard-overridden": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+      "integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.5",
@@ -19702,6 +8196,8 @@
     },
     "postcss-env-function": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+      "integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19710,6 +8206,8 @@
     },
     "postcss-focus-visible": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+      "integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19717,6 +8215,8 @@
     },
     "postcss-focus-within": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+      "integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19724,6 +8224,8 @@
     },
     "postcss-font-variant": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+      "integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19731,6 +8233,8 @@
     },
     "postcss-functions": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
+      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
       "dev": true,
       "requires": {
         "glob": "^7.1.2",
@@ -19741,6 +8245,8 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -19752,6 +8258,8 @@
     },
     "postcss-gap-properties": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+      "integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19759,6 +8267,8 @@
     },
     "postcss-image-set-function": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+      "integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -19767,6 +8277,8 @@
     },
     "postcss-import": {
       "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
+      "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.1",
@@ -19777,6 +8289,8 @@
     },
     "postcss-initial": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
+      "integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
       "dev": true,
       "requires": {
         "lodash.template": "^4.5.0",
@@ -19785,6 +8299,8 @@
     },
     "postcss-js": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
+      "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
       "dev": true,
       "requires": {
         "camelcase-css": "^2.0.1",
@@ -19793,6 +8309,8 @@
     },
     "postcss-lab-function": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+      "integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
       "dev": true,
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -19802,6 +8320,8 @@
     },
     "postcss-load-config": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
       "requires": {
         "cosmiconfig": "^5.0.0",
         "import-cwd": "^2.0.0"
@@ -19809,6 +8329,8 @@
     },
     "postcss-loader": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "requires": {
         "loader-utils": "^1.1.0",
         "postcss": "^7.0.0",
@@ -19818,6 +8340,8 @@
     },
     "postcss-logical": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
+      "integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19825,6 +8349,8 @@
     },
     "postcss-media-minmax": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+      "integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19832,6 +8358,8 @@
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
       "requires": {
         "css-color-names": "0.0.4",
         "postcss": "^7.0.0",
@@ -19841,6 +8369,8 @@
     },
     "postcss-merge-rules": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-api": "^3.0.0",
@@ -19852,15 +8382,21 @@
       "dependencies": {
         "dot-prop": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
           }
         },
         "is-obj": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "requires": {
             "dot-prop": "^5.2.0",
             "indexes-of": "^1.0.1",
@@ -19871,6 +8407,8 @@
     },
     "postcss-minify-font-values": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "requires": {
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
@@ -19878,6 +8416,8 @@
     },
     "postcss-minify-gradients": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "is-color-stop": "^1.0.0",
@@ -19887,6 +8427,8 @@
     },
     "postcss-minify-params": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "requires": {
         "alphanum-sort": "^1.0.0",
         "browserslist": "^4.0.0",
@@ -19898,6 +8440,8 @@
     },
     "postcss-minify-selectors": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
       "requires": {
         "alphanum-sort": "^1.0.0",
         "has": "^1.0.0",
@@ -19907,15 +8451,21 @@
       "dependencies": {
         "dot-prop": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
           }
         },
         "is-obj": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "requires": {
             "dot-prop": "^5.2.0",
             "indexes-of": "^1.0.1",
@@ -19926,12 +8476,16 @@
     },
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "requires": {
         "postcss": "^7.0.5"
       }
     },
     "postcss-modules-local-by-default": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+      "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
       "requires": {
         "postcss": "^7.0.6",
         "postcss-selector-parser": "^6.0.0",
@@ -19940,6 +8494,8 @@
     },
     "postcss-modules-scope": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
+      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
       "requires": {
         "postcss": "^7.0.6",
         "postcss-selector-parser": "^6.0.0"
@@ -19947,6 +8503,8 @@
     },
     "postcss-modules-values": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+      "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
       "requires": {
         "icss-replace-symbols": "^1.1.0",
         "postcss": "^7.0.6"
@@ -19954,6 +8512,8 @@
     },
     "postcss-nested": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
+      "integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.21",
@@ -19962,6 +8522,8 @@
     },
     "postcss-nesting": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
+      "integrity": "sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -19969,12 +8531,16 @@
     },
     "postcss-normalize-charset": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "requires": {
         "postcss": "^7.0.0"
       }
     },
     "postcss-normalize-display-values": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
         "postcss": "^7.0.0",
@@ -19983,6 +8549,8 @@
     },
     "postcss-normalize-positions": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "has": "^1.0.0",
@@ -19992,6 +8560,8 @@
     },
     "postcss-normalize-repeat-style": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "cssnano-util-get-match": "^4.0.0",
@@ -20001,6 +8571,8 @@
     },
     "postcss-normalize-string": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
       "requires": {
         "has": "^1.0.0",
         "postcss": "^7.0.0",
@@ -20009,6 +8581,8 @@
     },
     "postcss-normalize-timing-functions": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
         "postcss": "^7.0.0",
@@ -20017,6 +8591,8 @@
     },
     "postcss-normalize-unicode": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "requires": {
         "browserslist": "^4.0.0",
         "postcss": "^7.0.0",
@@ -20025,6 +8601,8 @@
     },
     "postcss-normalize-url": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "requires": {
         "is-absolute-url": "^2.0.0",
         "normalize-url": "^3.0.0",
@@ -20034,6 +8612,8 @@
     },
     "postcss-normalize-whitespace": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "requires": {
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
@@ -20041,6 +8621,8 @@
     },
     "postcss-ordered-values": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "postcss": "^7.0.0",
@@ -20049,6 +8631,8 @@
     },
     "postcss-overflow-shorthand": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+      "integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -20056,6 +8640,8 @@
     },
     "postcss-page-break": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+      "integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -20063,6 +8649,8 @@
     },
     "postcss-place": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
+      "integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -20071,6 +8659,8 @@
     },
     "postcss-preset-env": {
       "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+      "integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
       "dev": true,
       "requires": {
         "autoprefixer": "^9.6.1",
@@ -20114,6 +8704,8 @@
     },
     "postcss-pseudo-class-any-link": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+      "integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2",
@@ -20122,10 +8714,14 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
           "dev": true
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "dev": true,
           "requires": {
             "cssesc": "^2.0.0",
@@ -20137,6 +8733,8 @@
     },
     "postcss-reduce-initial": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-api": "^3.0.0",
@@ -20146,6 +8744,8 @@
     },
     "postcss-reduce-transforms": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
         "has": "^1.0.0",
@@ -20155,6 +8755,8 @@
     },
     "postcss-replace-overflow-wrap": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+      "integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.2"
@@ -20162,6 +8764,8 @@
     },
     "postcss-selector-matches": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+      "integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -20170,6 +8774,8 @@
     },
     "postcss-selector-not": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+      "integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -20178,6 +8784,8 @@
     },
     "postcss-selector-parser": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -20186,6 +8794,8 @@
     },
     "postcss-svgo": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+      "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "requires": {
         "is-svg": "^3.0.0",
         "postcss": "^7.0.0",
@@ -20195,6 +8805,8 @@
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "requires": {
         "alphanum-sort": "^1.0.0",
         "postcss": "^7.0.0",
@@ -20202,10 +8814,14 @@
       }
     },
     "postcss-value-parser": {
-      "version": "3.3.1"
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "postcss-values-parser": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
       "dev": true,
       "requires": {
         "flatten": "^1.0.2",
@@ -20215,6 +8831,8 @@
     },
     "prebuild-install": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -20234,13 +8852,19 @@
       }
     },
     "prepend-http": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.16.3"
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
     },
     "pretty-error": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
         "renderkid": "^2.0.1",
         "utila": "~0.4"
@@ -20248,24 +8872,34 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
     "prism-themes": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.3.0.tgz",
+      "integrity": "sha512-4hDQyNuBRyWVvwHeTH4yY5TIWrl6BHmhoh85kgfTFgwklGerWA3R2RFp7Sg0zPCnQS8SsloKsEIN3ao63KhiIw==",
       "dev": true
     },
     "prismjs": {
       "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
+      "integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
       "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
     },
     "private": {
-      "version": "0.1.8"
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "probe-image-size": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.1.1.tgz",
+      "integrity": "sha512-42LqKZqTLxH/UvAZ2/cKhAsR4G/Y6B7i7fI2qtQu9hRBK4YjS6gqO+QRtwTjvojUx4+/+JuOMzLoFyRecT9qRw==",
       "requires": {
         "any-promise": "^1.3.0",
         "deepmerge": "^4.0.0",
@@ -20276,42 +8910,62 @@
       }
     },
     "process": {
-      "version": "0.11.10"
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-inflight": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "property-information": {
       "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
+      "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
     },
     "proto-list": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
     "proxy-addr": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
     },
     "prr": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -20323,6 +8977,8 @@
     },
     "pump": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -20330,6 +8986,8 @@
     },
     "pumpify": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -20338,6 +8996,8 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -20346,10 +9006,14 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "purgecss": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.1.0.tgz",
+      "integrity": "sha512-QnXhowNjeWo9vNnGES2LVzDXdRR/8EvG/O03m4bYOWfAX0ShmG/Pmj7brVtVBy2eaaRAmNy23L+GBc4SpDFUeQ==",
       "dev": true,
       "requires": {
         "commander": "^4.0.0",
@@ -20360,18 +9024,26 @@
       "dependencies": {
         "commander": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
         }
       }
     },
     "q": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.7.0"
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -20379,32 +9051,46 @@
       }
     },
     "querystring": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.3",
@@ -20414,6 +9100,8 @@
     },
     "rc": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -20423,6 +9111,8 @@
     },
     "read-cache": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -20430,12 +9120,16 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -20444,6 +9138,8 @@
       "dependencies": {
         "path-type": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -20451,12 +9147,16 @@
           }
         },
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "read-pkg-up": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -20464,6 +9164,8 @@
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -20471,6 +9173,8 @@
         },
         "path-exists": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -20479,6 +9183,8 @@
     },
     "readable-stream": {
       "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -20490,10 +9196,14 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -20502,6 +9212,8 @@
     },
     "readdirp": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -20510,6 +9222,8 @@
     },
     "redent": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -20517,6 +9231,8 @@
     },
     "reduce-css-calc": {
       "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.7.tgz",
+      "integrity": "sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==",
       "dev": true,
       "requires": {
         "css-unit-converter": "^1.1.1",
@@ -20524,25 +9240,35 @@
       }
     },
     "regenerate": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "requires": {
         "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3"
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "requires": {
         "private": "^0.1.6"
       }
     },
     "regex-not": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -20550,6 +9276,8 @@
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -20557,6 +9285,8 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -20565,6 +9295,8 @@
     },
     "regexpu-core": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.1.0",
@@ -20576,35 +9308,49 @@
     },
     "registry-auth-token": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
       "requires": {
         "rc": "^1.2.8"
       }
     },
     "registry-url": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "requires": {
         "rc": "^1.2.8"
       }
     },
     "regjsgen": {
-      "version": "0.5.1"
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
     },
     "regjsparser": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
+      "integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
       "requires": {
         "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
-          "version": "0.5.0"
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "relateurl": {
-      "version": "0.2.7"
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remark-autolink-headings": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/remark-autolink-headings/-/remark-autolink-headings-5.2.1.tgz",
+      "integrity": "sha512-pAsIVtbYWIkCDoR/hXJQAjXRnzQ5hjQzmiz2eQnZMIQbsiut3x5xEQYF+urpNEQSUG1/I+9wp2sSERgaxiaBdQ==",
       "dev": true,
       "requires": {
         "extend": "^3.0.2",
@@ -20613,6 +9359,8 @@
     },
     "remark-external-links": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-3.1.1.tgz",
+      "integrity": "sha512-QeqEeThumJ6GJzzgP45XY7+C6IGdvRxy8WkJNL/jRaeiGLDxmBUx0ggFIm5N5tHU3O8KbUrxM4tZgAHb53hddg==",
       "dev": true,
       "requires": {
         "is-absolute-url": "^2.1.0",
@@ -20623,6 +9371,8 @@
     },
     "remark-fix-guillemets": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.0.tgz",
+      "integrity": "sha512-Cn4TyeXlyMajqdYjbFf9b76Ozffx/tvyr9m4Q9sypoGZ/CMA+du+kLE54T+j+5n9asEU7+cpiSZTimD4s+1Izg==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^2.0.1"
@@ -20630,10 +9380,14 @@
       "dependencies": {
         "unist-util-is": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
           "dev": true
         },
         "unist-util-visit": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+          "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
           "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
@@ -20643,6 +9397,8 @@
         },
         "unist-util-visit-parents": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+          "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
           "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
@@ -20653,6 +9409,8 @@
     },
     "remark-html": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-8.0.0.tgz",
+      "integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
       "dev": true,
       "requires": {
         "hast-util-sanitize": "^1.0.0",
@@ -20663,6 +9421,8 @@
     },
     "remark-parse": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
@@ -20684,6 +9444,8 @@
     },
     "remark-slug": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-4.2.3.tgz",
+      "integrity": "sha1-jZh9Dl5j1KSeo3uQ/pmaPc/IG3I=",
       "dev": true,
       "requires": {
         "github-slugger": "^1.0.0",
@@ -20693,16 +9455,22 @@
     },
     "remark-squeeze-paragraphs": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
+      "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
       "dev": true,
       "requires": {
         "mdast-squeeze-paragraphs": "^3.0.0"
       }
     },
     "remove-trailing-separator": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
       "requires": {
         "css-select": "^1.1.0",
         "dom-converter": "^0.2",
@@ -20712,22 +9480,32 @@
       }
     },
     "repeat-element": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
     },
     "repeat-string": {
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -20752,100 +9530,144 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.5.2"
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
     "require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "requires-port": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
         "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-url": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "responselike": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
     },
     "ret": {
-      "version": "0.1.15"
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "reusify": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rgb-regex": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
     },
     "rgba-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
     },
     "ripemd160": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
     },
     "run-parallel": {
-      "version": "1.1.9"
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "run-queue": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
         "aproba": "^1.1.1"
       }
     },
     "safe-buffer": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
       "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.22.0.tgz",
+      "integrity": "sha512-3RPo65mbTKpOAdAYWU496MSty1YbB3Y5bjwL5OclgaSSMtv65xvM7RW/EHRumzaZ1UddEJowCbSdK0xl5sAu0A==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -20862,10 +9684,14 @@
       "dependencies": {
         "domelementtype": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
           "dev": true
         },
         "domutils": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
+          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
           "dev": true,
           "requires": {
             "dom-serializer": "^0.2.1",
@@ -20875,6 +9701,8 @@
         },
         "htmlparser2": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
           "dev": true,
           "requires": {
             "domelementtype": "^2.0.1",
@@ -20887,6 +9715,8 @@
     },
     "sass-graph": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -20897,6 +9727,8 @@
     },
     "sass-loader": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
@@ -20908,6 +9740,8 @@
       "dependencies": {
         "schema-utils": {
           "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
           "dev": true,
           "requires": {
             "ajv": "^6.10.2",
@@ -20916,15 +9750,21 @@
         },
         "semver": {
           "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
     "sax": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "requires": {
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
@@ -20933,6 +9773,8 @@
     },
     "scss-tokenizer": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
         "js-base64": "^2.1.8",
@@ -20941,6 +9783,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
@@ -20950,6 +9794,8 @@
     },
     "section-matter": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -20958,12 +9804,16 @@
     },
     "seek-bzip": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
         "commander": "~2.8.1"
       },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -20972,29 +9822,41 @@
     },
     "select": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true,
       "optional": true
     },
     "semver": {
-      "version": "5.7.1"
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
       }
     },
     "semver-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
     },
     "semver-truncate": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "requires": {
         "semver": "^5.3.0"
       }
     },
     "send": {
       "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -21012,18 +9874,26 @@
       },
       "dependencies": {
         "mime": {
-          "version": "1.6.0"
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "ms": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-static": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -21032,10 +9902,14 @@
       }
     },
     "set-blocking": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -21044,13 +9918,19 @@
       }
     },
     "setimmediate": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -21058,6 +9938,8 @@
     },
     "shallow-clone": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
@@ -21065,6 +9947,8 @@
     },
     "sharp": {
       "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
+      "integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
       "requires": {
         "color": "^3.1.2",
         "detect-libc": "^1.0.3",
@@ -21078,10 +9962,14 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "tar": {
           "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+          "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
           "requires": {
             "chownr": "^1.1.3",
             "fs-minipass": "^2.0.0",
@@ -21095,21 +9983,31 @@
     },
     "shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
         "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
       "requires": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -21118,23 +10016,31 @@
       "dependencies": {
         "decompress-response": {
           "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
           "requires": {
             "mimic-response": "^2.0.0"
           }
         },
         "mimic-response": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
         }
       }
     },
     "simple-swizzle": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
       }
     },
     "sitemap": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-2.2.0.tgz",
+      "integrity": "sha512-9Zoi3UBhSIt5jWENDRUbzsqLMJ+Fha3P2aQ2PRghmh0FOivtHsC4FAJdkAEKHvATajd74BWp/57Yh7kz/UA53Q==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10",
@@ -21143,10 +10049,14 @@
       }
     },
     "slash": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "snapdragon": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -21159,12 +10069,16 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7"
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "snapdragon-node": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -21173,6 +10087,8 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -21181,12 +10097,16 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -21195,6 +10115,8 @@
     },
     "sockjs": {
       "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+      "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
@@ -21202,6 +10124,8 @@
     },
     "sockjs-client": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+      "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
       "requires": {
         "debug": "^3.2.5",
         "eventsource": "^1.0.7",
@@ -21213,12 +10137,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "faye-websocket": {
           "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
@@ -21227,21 +10155,29 @@
     },
     "sort-keys": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "requires": {
         "sort-keys": "^1.0.0"
       }
     },
     "sort-object-keys": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
     },
     "sort-package-json": {
       "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.40.0.tgz",
+      "integrity": "sha512-3Uc1kjmQ3SYuKziKghZvA23SihOqGxEjK2QPfFPmd7BMo9rWiJdC2FJWvAZbfhLWapuJrdmkUf6Kp0G4Wtuv5w==",
       "requires": {
         "detect-indent": "^6.0.0",
         "detect-newline": "3.1.0",
@@ -21252,22 +10188,30 @@
       },
       "dependencies": {
         "array-union": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
         "braces": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
             "fill-range": "^7.0.1"
           }
         },
         "dir-glob": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
           "requires": {
             "path-type": "^4.0.0"
           }
         },
         "fast-glob": {
           "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+          "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
@@ -21279,18 +10223,24 @@
         },
         "fill-range": {
           "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "requires": {
             "to-regex-range": "^5.0.1"
           }
         },
         "glob-parent": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
           "requires": {
             "is-glob": "^4.0.1"
           }
         },
         "globby": {
           "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
           "requires": {
             "@types/glob": "^7.1.1",
             "array-union": "^2.1.0",
@@ -21303,29 +10253,43 @@
           }
         },
         "ignore": {
-          "version": "5.1.4"
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
         },
         "is-number": {
-          "version": "7.0.0"
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-plain-obj": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
         },
         "micromatch": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
           }
         },
         "path-type": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "slash": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "to-regex-range": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "requires": {
             "is-number": "^7.0.0"
           }
@@ -21333,13 +10297,19 @@
       }
     },
     "source-list-map": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
     },
     "source-map": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -21350,46 +10320,64 @@
     },
     "source-map-support": {
       "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
     "source-map-url": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "space-separated-tokens": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5"
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "split-string": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -21397,6 +10385,8 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -21404,10 +10394,14 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "squeak": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+      "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "requires": {
         "chalk": "^1.0.0",
         "console-stream": "^0.1.1",
@@ -21415,10 +10409,14 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -21428,16 +10426,22 @@
           }
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "srcset": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-2.0.1.tgz",
+      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -21452,35 +10456,51 @@
     },
     "ssri": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
     },
     "stable": {
-      "version": "0.1.8"
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-trace": {
-      "version": "0.0.10"
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stackframe": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+      "integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
     },
     "state-toggle": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
       }
     },
     "statuses": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdout-stream": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
@@ -21488,6 +10508,8 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -21495,6 +10517,8 @@
     },
     "stream-each": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -21502,6 +10526,8 @@
     },
     "stream-http": {
       "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -21512,24 +10538,26 @@
     },
     "stream-parser": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
       "requires": {
         "debug": "2"
       }
     },
     "stream-shift": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
-      "version": "1.1.0"
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -21538,6 +10566,8 @@
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -21546,6 +10576,8 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -21553,13 +10585,25 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "stringify-entities": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "dev": true,
       "requires": {
         "character-entities-html4": "^1.0.0",
@@ -21570,46 +10614,64 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
         "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true
     },
     "strip-dirs": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "requires": {
         "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
         "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "strip-outer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
     },
     "stylehacks": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+      "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "requires": {
         "browserslist": "^4.0.0",
         "postcss": "^7.0.0",
@@ -21618,15 +10680,21 @@
       "dependencies": {
         "dot-prop": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
           }
         },
         "is-obj": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "requires": {
             "dot-prop": "^5.2.0",
             "indexes-of": "^1.0.1",
@@ -21637,15 +10705,21 @@
     },
     "supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
       }
     },
     "svg-tags": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "svgo": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
@@ -21664,6 +10738,8 @@
       "dependencies": {
         "css-select": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
           "requires": {
             "boolbase": "^1.0.0",
             "css-what": "^3.2.1",
@@ -21672,12 +10748,16 @@
           }
         },
         "css-what": {
-          "version": "3.2.1"
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+          "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
         }
       }
     },
     "tailwindcss": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.2.0.tgz",
+      "integrity": "sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==",
       "dev": true,
       "requires": {
         "autoprefixer": "^9.4.5",
@@ -21700,6 +10780,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
@@ -21708,6 +10790,8 @@
         },
         "chalk": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -21716,6 +10800,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -21723,6 +10809,8 @@
         },
         "fs-extra": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -21732,10 +10820,14 @@
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -21744,10 +10836,14 @@
       }
     },
     "tapable": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
@@ -21757,6 +10853,8 @@
     },
     "tar-fs": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp": "^0.5.1",
@@ -21766,6 +10864,8 @@
     },
     "tar-stream": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
       "requires": {
         "bl": "^3.0.0",
         "end-of-stream": "^1.4.1",
@@ -21776,6 +10876,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -21785,10 +10887,14 @@
       }
     },
     "temp-dir": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
     },
     "tempfile": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -21796,12 +10902,16 @@
     },
     "term-size": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
         "execa": "^0.7.0"
       }
     },
     "terser": {
       "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
+      "integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -21810,6 +10920,8 @@
     },
     "terser-webpack-plugin": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
@@ -21823,49 +10935,71 @@
       }
     },
     "through": {
-      "version": "2.3.8"
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
     },
     "timed-out": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timers-browserify": {
       "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
       }
     },
     "timsort": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tiny-emitter": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "dev": true,
       "optional": true
     },
     "to-arraybuffer": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "to-buffer": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -21873,10 +11007,14 @@
       }
     },
     "to-readable-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -21886,6 +11024,8 @@
       "dependencies": {
         "define-property": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -21893,6 +11033,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -21900,6 +11042,8 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -21908,19 +11052,27 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
     },
     "toidentifier": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "toposort": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
     },
     "tough-cookie": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -21928,78 +11080,112 @@
     },
     "trim": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
     "trim-lines": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
+      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
       "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-repeated": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-trailing-lines": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
     "trough": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "true-case-path": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
         "glob": "^7.1.2"
       }
     },
     "tslib": {
-      "version": "1.11.0"
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
     },
     "tty-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
-      "version": "0.14.5"
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-fest": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "type-is": {
       "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+      "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
       "requires": {
         "commander": "~2.19.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0"
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         }
       }
     },
     "unbzip2-stream": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -22007,6 +11193,8 @@
       "dependencies": {
         "buffer": {
           "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -22015,10 +11203,14 @@
       }
     },
     "unc-path-regex": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "unherit": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.0",
@@ -22026,23 +11218,33 @@
       }
     },
     "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
@@ -22057,10 +11259,14 @@
       "dependencies": {
         "is-buffer": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
         },
         "vfile": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
           "dev": true,
           "requires": {
             "is-buffer": "^2.0.0",
@@ -22071,6 +11277,8 @@
         },
         "vfile-message": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
           "dev": true,
           "requires": {
             "unist-util-stringify-position": "^1.1.1"
@@ -22080,6 +11288,8 @@
     },
     "union-value": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -22088,31 +11298,43 @@
       }
     },
     "uniq": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "uniqs": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
     "unique-filename": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "requires": {
         "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
     },
     "unist-builder": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
+      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.0"
@@ -22120,18 +11342,26 @@
     },
     "unist-util-generated": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
+      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==",
       "dev": true
     },
     "unist-util-is": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "dev": true
     },
     "unist-util-position": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
+      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
       "dev": true
     },
     "unist-util-remove": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
+      "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
       "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
@@ -22139,6 +11369,8 @@
     },
     "unist-util-remove-position": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -22146,10 +11378,14 @@
     },
     "unist-util-stringify-position": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
       "dev": true
     },
     "unist-util-visit": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
@@ -22157,22 +11393,32 @@
     },
     "unist-util-visit-parents": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
       }
     },
     "universalify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unquote": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -22180,6 +11426,8 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -22188,6 +11436,8 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -22195,15 +11445,21 @@
           }
         },
         "has-values": {
-          "version": "0.1.4"
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
     "upath": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "update-notifier": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
       "requires": {
         "boxen": "^3.0.0",
         "chalk": "^2.0.1",
@@ -22220,35 +11476,49 @@
       }
     },
     "upper-case": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "urix": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
     "url-join": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "url-loader": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
+      "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
       "requires": {
         "loader-utils": "^1.1.0",
         "mime": "^2.0.3",
@@ -22257,6 +11527,8 @@
     },
     "url-parse": {
       "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -22264,32 +11536,46 @@
     },
     "url-parse-lax": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "requires": {
         "prepend-http": "^2.0.0"
       }
     },
     "url-to-options": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "util": {
       "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "requires": {
         "inherits": "2.0.3"
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.2",
@@ -22298,29 +11584,43 @@
       }
     },
     "utila": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
     "utils-merge": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
+      "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w=="
     },
     "verror": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -22328,12 +11628,16 @@
       },
       "dependencies": {
         "extsprintf": {
-          "version": "1.4.0"
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+          "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
         }
       }
     },
     "vfile": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+      "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
       "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
@@ -22345,10 +11649,14 @@
       "dependencies": {
         "is-buffer": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
         },
         "unist-util-stringify-position": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+          "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
           "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
@@ -22358,10 +11666,14 @@
     },
     "vfile-location": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
     "vfile-message": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
       "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
@@ -22370,6 +11682,8 @@
       "dependencies": {
         "unist-util-stringify-position": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+          "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
           "dev": true,
           "requires": {
             "@types/unist": "^2.0.2"
@@ -22378,27 +11692,39 @@
       }
     },
     "vm-browserify": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "vue": {
-      "version": "2.6.11"
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
     "vue-analytics": {
       "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz",
+      "integrity": "sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==",
       "dev": true
     },
     "vue-feather-icons": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vue-feather-icons/-/vue-feather-icons-5.0.0.tgz",
+      "integrity": "sha512-uvi2l3i0aeRRzG3vX24/AH+8BkcXkSJboAv8XkUZ6aPkEC9n6LXDcKp5/ho+3moVQ9wlga3N6BjL89pmkHBzPw==",
       "dev": true,
       "requires": {
         "babel-helper-vue-jsx-merge-props": "^2.0.2"
       }
     },
     "vue-hot-reload-api": {
-      "version": "2.3.4"
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+      "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "vue-loader": {
       "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.0.tgz",
+      "integrity": "sha512-FeDHvTSpwyLeF7LIV1PYkvqUQgTJ8UmOxhSlCyRSxaXCKk+M6NF4tDQsLsPPNeDPyR7TfRQ8MLg6v+8PsDV9xQ==",
       "requires": {
         "@vue/component-compiler-utils": "^3.1.0",
         "hash-sum": "^1.0.2",
@@ -22409,6 +11735,8 @@
       "dependencies": {
         "@vue/component-compiler-utils": {
           "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.1.1.tgz",
+          "integrity": "sha512-+lN3nsfJJDGMNz7fCpcoYIORrXo0K3OTsdr8jCM7FuqdI4+70TY6gxY6viJ2Xi1clqyPg7LpeOWwjF31vSMmUw==",
           "requires": {
             "consolidate": "^0.15.1",
             "hash-sum": "^1.0.2",
@@ -22422,21 +11750,29 @@
           }
         },
         "prettier": {
-          "version": "1.19.1"
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
         }
       }
     },
     "vue-meta": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-2.3.2.tgz",
+      "integrity": "sha512-6xKy+K1J4yCs16x4UhvYI2joKADPnxxPcCUkzckaUt6xqMonBCYwK0JSh8BicooDpKcrre6JGZcQRIVIDttOVg==",
       "requires": {
         "deepmerge": "^4.2.2"
       }
     },
     "vue-router": {
-      "version": "3.1.5"
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.5.tgz",
+      "integrity": "sha512-BszkPvhl7I9h334GjckCh7sVFyjTPMMJFJ4Bsrem/Ik+B/9gt5tgrk8k4gGLO4ZpdvciVdg7O41gW4DisQWurg=="
     },
     "vue-server-renderer": {
       "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.11.tgz",
+      "integrity": "sha512-V3faFJHr2KYfdSIalL+JjinZSHYUhlrvJ9pzCIjjwSh77+pkrsXpK4PucdPcng57+N77pd1LrKqwbqjQdktU1A==",
       "requires": {
         "chalk": "^1.1.3",
         "hash-sum": "^1.0.2",
@@ -22449,10 +11785,14 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -22462,15 +11802,21 @@
           }
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "vue-style-loader": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
+      "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
       "requires": {
         "hash-sum": "^1.0.2",
         "loader-utils": "^1.0.2"
@@ -22478,16 +11824,22 @@
     },
     "vue-template-compiler": {
       "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
       "requires": {
         "de-indent": "^1.0.2",
         "he": "^1.1.0"
       }
     },
     "vue-template-es2015-compiler": {
-      "version": "1.9.1"
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
+      "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "watchpack": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
         "chokidar": "^2.0.2",
         "graceful-fs": "^4.1.2",
@@ -22496,12 +11848,16 @@
     },
     "wcwidth": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "requires": {
         "defaults": "^1.0.3"
       }
     },
     "webpack": {
       "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -22530,18 +11886,24 @@
     },
     "webpack-chain": {
       "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-5.2.4.tgz",
+      "integrity": "sha512-3g0uIbzM/EWnmf52bYhB5IZeBZiw5g9vNqF4iTBEqabpxGxcv+Aj9oL4Cvr19ujOsv/HPvpRFRPLZ/aylv10Wg==",
       "requires": {
         "deepmerge": "^1.5.2",
         "javascript-stringify": "^2.0.0"
       },
       "dependencies": {
         "deepmerge": {
-          "version": "1.5.2"
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+          "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
       "requires": {
         "memory-fs": "^0.4.1",
         "mime": "^2.4.4",
@@ -22552,6 +11914,8 @@
     },
     "webpack-hot-middleware": {
       "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz",
+      "integrity": "sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==",
       "requires": {
         "ansi-html": "0.0.7",
         "html-entities": "^1.2.0",
@@ -22561,6 +11925,8 @@
     },
     "webpack-log": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
@@ -22568,12 +11934,16 @@
     },
     "webpack-merge": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "requires": {
         "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
@@ -22581,6 +11951,8 @@
     },
     "websocket-driver": {
       "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
         "http-parser-js": ">=0.4.0 <0.4.11",
         "safe-buffer": ">=5.1.0",
@@ -22588,32 +11960,46 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
     },
     "which-module": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "which-pm-runs": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -22621,6 +12007,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -22629,15 +12017,21 @@
     },
     "widest-line": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "requires": {
         "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -22645,6 +12039,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -22653,16 +12049,22 @@
     },
     "wordwrap": {
       "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
         "string-width": "^1.0.1",
@@ -22670,10 +12072,14 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -22682,33 +12088,49 @@
     },
     "x-is-string": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
     },
     "xdg-basedir": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xmlbuilder": {
       "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
       "dev": true
     },
     "xtend": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml-loader": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.5.0.tgz",
+      "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
       "requires": {
         "js-yaml": "^3.5.2"
       }
     },
     "yargs": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
         "camelcase": "^3.0.0",
@@ -22728,12 +12150,16 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
       }
     },
     "yargs-parser": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
         "camelcase": "^3.0.0"
@@ -22741,12 +12167,16 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
       }
     },
     "yauzl": {
       "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "explore": "gridsome explore"
   },
   "dependencies": {
+    "@gridsome/vue-remark": "^0.2.6",
     "axios": "^0.21.0",
-    "gridsome": "^0.7.0"
+    "gridsome": "^0.7.0",
+    "vue-carousel": "^0.18.0"
   },
   "devDependencies": {
     "@gridsome/plugin-google-analytics": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "explore": "gridsome explore"
   },
   "dependencies": {
-    "@gridsome/vue-remark": "^0.2.6",
     "axios": "^0.21.0",
     "gridsome": "^0.7.0",
     "vue-carousel": "^0.18.0"
@@ -18,6 +17,7 @@
     "@gridsome/remark-prismjs": "^0.3.0",
     "@gridsome/source-filesystem": "^0.6.2",
     "@gridsome/transformer-remark": "^0.5.0",
+    "@gridsome/vue-remark": "^0.2.6",
     "fuse.js": "^3.4.6",
     "gridsome-plugin-tailwindcss": "^2.2.36",
     "node-sass": "^4.13.1",

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -1,0 +1,38 @@
+<template>
+	<ClientOnly>
+		<carousel :perPage="1">
+			<slide v-for="item in items" :key="item">
+				<img class="slide-image" v-bind:src="item.image" />
+                <p class="slide-title"><b v-if="item.title">{{ item.title }}</b></p>
+				<p class="slide-desc" v-if="item.desc">{{ item.desc }}</p>
+			</slide>
+		</carousel>
+	</ClientOnly>
+</template>
+
+<script>
+export default {
+	props: {
+		items: Array
+	},
+	components: {
+		Carousel: () =>
+			import("vue-carousel")
+				.then((m) => m.Carousel)
+				.catch(),
+		Slide: () =>
+			import("vue-carousel")
+				.then((m) => m.Slide)
+				.catch(),
+	},
+};
+</script>
+
+<style>
+.slide-image {
+    margin: auto;
+}
+.slide-title, .slide-desc {
+    text-align: center;
+}
+</style>

--- a/src/components/download/DownloadButtons.vue
+++ b/src/components/download/DownloadButtons.vue
@@ -1,0 +1,16 @@
+<template>
+	<h1>{{ message }}</h1>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			message: "Hello from DownloadButtons! 👋",
+		};
+	},
+};
+</script>
+
+<style>
+</style>

--- a/src/components/download/WhatsNew.vue
+++ b/src/components/download/WhatsNew.vue
@@ -1,0 +1,16 @@
+<template>
+	<h1>{{ message }}</h1>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			message: "Hello from DownloadButtons! 👋",
+		};
+	},
+};
+</script>
+
+<style>
+</style>

--- a/src/templates/MarkdownPage.vue
+++ b/src/templates/MarkdownPage.vue
@@ -1,21 +1,19 @@
 <template>
-  <Layout>
-      <div class="flex flex-wrap items-start justify-start">
+	<Layout>
+		<div class="flex flex-wrap items-start justify-start">
+			<div class="order-2 w-full md:w-1/3 sm:pl-4 md:pl-6 lg:pl-8 sticky" style="top: 4rem">
+				<OnThisPage />
+			</div>
 
-        <div class="order-2 w-full md:w-1/3 sm:pl-4 md:pl-6 lg:pl-8 sticky" style="top: 4rem">
-          <OnThisPage />
-        </div>
+			<div class="order-1 w-full md:w-2/3">
+				<VueRemarkContent />
 
-        <div class="order-1 w-full md:w-2/3">
-          <div class="content" v-html="$page.markdownPage.content" />
-
-          <div class="mt-8 pt-8 lg:mt-12 lg:pt-12 border-t border-ui-border">
-            <NextPrevLinks />
-          </div>
-        </div>
-
-      </div>
-  </Layout>
+				<div class="mt-8 pt-8 lg:mt-12 lg:pt-12 border-t border-ui-border">
+					<NextPrevLinks />
+				</div>
+			</div>
+		</div>
+	</Layout>
 </template>
 
 <page-query>
@@ -25,7 +23,6 @@ query ($id: ID!) {
     title
     description
     path
-    timeToRead
     content
     sidebar
     next
@@ -48,52 +45,52 @@ query ($id: ID!) {
 </page-query>
 
 <script>
-import OnThisPage from '@/components/OnThisPage.vue';
-import NextPrevLinks from '@/components/NextPrevLinks.vue';
+import OnThisPage from "@/components/OnThisPage.vue";
+import NextPrevLinks from "@/components/NextPrevLinks.vue";
 
 export default {
-  components: {
-    OnThisPage,
-    NextPrevLinks
-  },
-  
-  metaInfo() {
-    const title = this.$page.markdownPage.title;
-    const description = this.$page.markdownPage.description || this.$page.markdownPage.excerpt;
+	components: {
+		OnThisPage,
+		NextPrevLinks,
+	},
 
-    return {
-      title: title,
-      meta: [
-        {
-          name: 'description',
-          content: description
-        },
-        {
-          key: 'og:title',
-          name: 'og:title',
-          content: title,
-        },
-        {
-          key: 'twitter:title',
-          name: 'twitter:title',
-          content: title,
-        },
-        {
-          key: 'og:description',
-          name: 'og:description',
-          content: description,
-        },
-        {
-          key: 'twitter:description',
-          name: 'twitter:description',
-          content: description,
-        },
-      ]
-    }
-  }
-}
+	metaInfo() {
+		const title = this.$page.markdownPage.title;
+		const description = this.$page.markdownPage.description || this.$page.markdownPage.excerpt;
+
+		return {
+			title: title,
+			meta: [
+				{
+					name: "description",
+					content: description,
+				},
+				{
+					key: "og:title",
+					name: "og:title",
+					content: title,
+				},
+				{
+					key: "twitter:title",
+					name: "twitter:title",
+					content: title,
+				},
+				{
+					key: "og:description",
+					name: "og:description",
+					content: description,
+				},
+				{
+					key: "twitter:description",
+					name: "twitter:description",
+					content: description,
+				},
+			],
+		};
+	},
+};
 </script>
 
 <style>
-@import 'prism-themes/themes/prism-material-oceanic.css';
+@import "prism-themes/themes/prism-material-oceanic.css";
 </style>


### PR DESCRIPTION
What works:
- All markdown pages
- The carousel

What doesn't work
- All the old Vue components and things related to VuePress (They are currently surrounded with ` )
- All the old images (is currently replaced by https://tachiyomi.org/icons/logo.svg) 
- All the links to pages on the site

The component `DownloadButtons` and `WhatsNew ` are right now only placeholders

Layout like `ForkPage` and `Help` can be used for Gridsome as well with some tweaking